### PR TITLE
Refactor error handling take 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
@@ -39,16 +39,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
-
-[[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -61,43 +55,43 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.3"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
 name = "arraydeque"
@@ -107,36 +101,36 @@ checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.72"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c6a35df3749d2e8bb1b7b21a976d82b15548788d2735b9d82f329268f71a11"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bstr"
-version = "1.9.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
+checksum = "1a68f1f47cdf0ec8ee4b941b2eee2a80cb796db73118c0dd09ac63fbe405be22"
 dependencies = [
  "memchr",
  "serde",
@@ -150,15 +144,9 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
-
-[[package]]
-name = "cc"
-version = "1.0.99"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cfg-if"
@@ -168,9 +156,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -178,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
 dependencies = [
  "anstream",
  "anstyle",
@@ -191,27 +179,27 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.4"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "console"
@@ -253,19 +241,19 @@ checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "ctor"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
 name = "cucumber"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2940c675f8b0dd864bfedb4283d5fa07b8799eed59a4f7b09fb1257b18c88a1e"
+checksum = "6cd12917efc3a8b069a4975ef3cb2f2d835d42d04b3814d90838488f9dd9bf69"
 dependencies = [
  "anyhow",
  "clap",
@@ -292,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "cucumber-codegen"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5c9c7e0af8103f81ab300a21be3df1d57a003a151cf0bf41fdd343f85d14552"
+checksum = "9e19cd9e8e7cfd79fbf844eb6a7334117973c01f6bad35571262b00891e60f1c"
 dependencies = [
  "cucumber-expressions",
  "inflections",
@@ -302,7 +290,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.66",
+ "syn",
  "synthez",
 ]
 
@@ -322,13 +310,13 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.17"
+version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -339,9 +327,9 @@ checksum = "669a445ee724c5c69b1b06fe0b63e70a1c84bc9bb7d9696cd4f4e3ec45050408"
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "encode_unicode"
@@ -351,18 +339,18 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "env_filter"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
 dependencies = [
  "log",
  "regex",
@@ -370,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -389,19 +377,19 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -414,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -424,15 +412,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -441,38 +429,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -497,29 +485,29 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.66",
+ "syn",
  "textwrap",
- "thiserror",
+ "thiserror 1.0.69",
  "typed-builder",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "globset"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
 dependencies = [
  "aho-corasick",
  "bstr",
  "log",
  "regex-automata",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -540,16 +528,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
- "allocator-api2",
 ]
 
 [[package]]
-name = "hashlink"
-version = "0.8.4"
+name = "hashbrown"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -578,9 +571,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "ignore"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -594,12 +587,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -616,30 +609,30 @@ checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.0"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "lazy-regex"
-version = "3.1.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d12be4595afdf58bd19e4a9f4e24187da2a66700786ff660a418e9059937a4c"
+checksum = "8d8e41c97e6bc7ecb552016274b99fbb5d035e8de288c582d9b933af6677bfda"
 dependencies = [
  "lazy-regex-proc_macros",
  "once_cell",
@@ -648,27 +641,27 @@ dependencies = [
 
 [[package]]
 name = "lazy-regex-proc_macros"
-version = "3.1.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bcd58e6c97a7fcbaffcdc95728b393b8d98933bfadad49ed4097845b57ef0b"
+checksum = "76e1d8b05d672c53cb9c7b920bbba8783845ae4f0b076e02a3db1d02c81b4163"
 dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "c2ccc108bbc0b1331bd061864e7cd823c0cab660bbe6970e66e2c0614decde36"
 
 [[package]]
 name = "linked-hash-map"
@@ -694,15 +687,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "minimal-lexical"
@@ -712,22 +705,23 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
+ "hermit-abi",
  "libc",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -752,29 +746,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "object"
-version = "0.35.0"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "parking_lot"
@@ -796,7 +780,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -828,29 +812,29 @@ checksum = "9555b1514d2d99d78150d3c799d4c357a3e2c2a8062cd108e93a06d9057629c5"
 
 [[package]]
 name = "pin-project"
-version = "1.1.5"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.5"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -860,52 +844,52 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.84"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -916,9 +900,9 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-demangle"
@@ -928,9 +912,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
  "bitflags",
  "errno",
@@ -969,36 +953,37 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -1048,7 +1033,7 @@ checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
@@ -1059,9 +1044,9 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1075,20 +1060,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.66"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1101,7 +1075,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3d2c2202510a1e186e63e596d9318c91a8cbe85cd1a56a7be0c333e5f59ec8d"
 dependencies = [
- "syn 2.0.66",
+ "syn",
  "synthez-codegen",
  "synthez-core",
 ]
@@ -1112,7 +1086,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f724aa6d44b7162f3158a57bccd871a77b39a4aef737e01bcdff41f4772c7746"
 dependencies = [
- "syn 2.0.66",
+ "syn",
  "synthez-core",
 ]
 
@@ -1125,17 +1099,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sealed",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
 name = "terminal_size"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+checksum = "4f599bd7ca042cfdf8f4512b277c02ba102247820f9d9d4a9f521f496751a6ef"
 dependencies = [
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1151,52 +1125,71 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
@@ -1216,14 +1209,14 @@ checksum = "29a3151c41d0b13e3d011f98adc24434560ef06673a155a6c7f66b9879eecce2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-linebreak"
@@ -1233,9 +1226,9 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -1245,15 +1238,15 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -1273,20 +1266,11 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1295,135 +1279,87 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "yaml-rust2"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8902160c4e6f2fb145dbe9d6760a75e3c9522d8bf796ed7047c85919ac7115f8"
+checksum = "2a1a1c0bc9823338a3bdf8c61f994f23ac004c6fa32c08cd152984499b445e8d"
 dependencies = [
  "arraydeque",
  "encoding_rs",
@@ -1444,27 +1380,27 @@ dependencies = [
  "regex",
  "serde",
  "serde_yaml",
- "thiserror",
+ "thiserror 2.0.3",
  "tokio",
  "yaml-rust2",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +594,12 @@ dependencies = [
  "walkdir",
  "winapi-util",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
@@ -1370,11 +1386,11 @@ dependencies = [
 name = "yaml-schema"
 version = "0.3.0"
 dependencies = [
- "anyhow",
  "clap",
  "ctor",
  "cucumber",
  "env_logger",
+ "eyre",
  "futures",
  "log",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ log = "0.4.21"
 regex = "1.10.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
-thiserror = "1.0"
-yaml-rust2 = "0.8.1"
+thiserror = "2.0"
+yaml-rust2 = "0.9.0"
 
 [dev-dependencies]
 cucumber = "0.21.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,10 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.86"
 clap = { version = "4.5.4", features = ["cargo", "derive"] }
 ctor = "0.2.8"
 env_logger = "0.11.3"
+eyre = "0.6.8"
 futures = "0.3.30"
 log = "0.4.21"
 regex = "1.10.4"

--- a/src/deser.rs
+++ b/src/deser.rs
@@ -3,14 +3,14 @@ use std::collections::HashMap;
 use std::fmt;
 
 use crate::schemas::BooleanSchema;
-use crate::Error;
+use crate::Result;
 use crate::{unsupported_type, PropertyNamesValue};
 
 use super::{format_map, format_vec, Number};
 
 /// Instead of From<deser::YamlSchema>
 pub trait Deser<T>: Sized {
-    fn deserialize(&self) -> Result<T, Error>;
+    fn deserialize(&self) -> Result<T>;
 }
 
 /// A YamlSchema is either empty, a boolean, a typed schema, or an enum schema
@@ -124,7 +124,7 @@ impl YamlSchema {
 }
 
 impl Deser<crate::YamlSchema> for YamlSchema {
-    fn deserialize(&self) -> Result<crate::YamlSchema, Error> {
+    fn deserialize(&self) -> Result<crate::YamlSchema> {
         match &self {
             YamlSchema::Empty => Ok(crate::YamlSchema::Empty),
             YamlSchema::Boolean(b) => Ok(crate::YamlSchema::Boolean(*b)),
@@ -224,7 +224,7 @@ impl fmt::Display for TypedSchema {
 }
 
 impl Deser<crate::YamlSchema> for TypedSchema {
-    fn deserialize(&self) -> Result<crate::YamlSchema, Error> {
+    fn deserialize(&self) -> Result<crate::YamlSchema> {
         match &self.r#type {
             TypeValue::Single(s) => match s {
                 serde_yaml::Value::String(s) => match s.as_str() {

--- a/src/deser.rs
+++ b/src/deser.rs
@@ -2,15 +2,15 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
 
-use crate::error::YamlSchemaError;
 use crate::schemas::BooleanSchema;
+use crate::Error;
 use crate::{unsupported_type, PropertyNamesValue};
 
 use super::{format_map, format_vec, Number};
 
 /// Instead of From<deser::YamlSchema>
 pub trait Deser<T>: Sized {
-    fn deserialize(&self) -> Result<T, YamlSchemaError>;
+    fn deserialize(&self) -> Result<T, Error>;
 }
 
 /// A YamlSchema is either empty, a boolean, a typed schema, or an enum schema
@@ -124,7 +124,7 @@ impl YamlSchema {
 }
 
 impl Deser<crate::YamlSchema> for YamlSchema {
-    fn deserialize(&self) -> Result<crate::YamlSchema, YamlSchemaError> {
+    fn deserialize(&self) -> Result<crate::YamlSchema, Error> {
         match &self {
             YamlSchema::Empty => Ok(crate::YamlSchema::Empty),
             YamlSchema::Boolean(b) => Ok(crate::YamlSchema::Boolean(*b)),
@@ -224,7 +224,7 @@ impl fmt::Display for TypedSchema {
 }
 
 impl Deser<crate::YamlSchema> for TypedSchema {
-    fn deserialize(&self) -> Result<crate::YamlSchema, YamlSchemaError> {
+    fn deserialize(&self) -> Result<crate::YamlSchema, Error> {
         match &self.r#type {
             TypeValue::Single(s) => match s {
                 serde_yaml::Value::String(s) => match s.as_str() {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -4,6 +4,7 @@ use super::validation::Validator;
 pub use crate::validation::Context;
 pub use crate::validation::ValidationError;
 use crate::Error;
+use crate::Result;
 use crate::YamlSchema;
 
 pub struct Engine<'a> {
@@ -15,7 +16,7 @@ impl<'a> Engine<'a> {
         Engine { schema }
     }
 
-    pub fn evaluate(&self, yaml: &serde_yaml::Value, fail_fast: bool) -> Result<Context, Error> {
+    pub fn evaluate(&self, yaml: &serde_yaml::Value, fail_fast: bool) -> Result<Context> {
         debug!("Engine is running");
         let context = Context::new(fail_fast);
         let result = self.schema.validate(&context, yaml);
@@ -33,7 +34,7 @@ impl<'a> Engine<'a> {
 //         &self,
 //         context: &Context,
 //         value: &serde_yaml::Value,
-//     ) -> Result<(), Error> {
+//     ) -> Result<()> {
 //         if !value.is_bool() {
 //             context.add_error(format!("Expected a boolean, but got: {:?}", value));
 //             fail_fast!(context);
@@ -158,7 +159,7 @@ impl<'a> Engine<'a> {
 //         &self,
 //         context: &Context,
 //         value: &serde_yaml::Value,
-//     ) -> Result<(), Error> {
+//     ) -> Result<()> {
 //         match validate_string(
 //             self.min_length,
 //             self.max_length,
@@ -188,7 +189,7 @@ impl<'a> Engine<'a> {
 //         &self,
 //         context: &Context,
 //         value: &serde_yaml::Value,
-//     ) -> Result<(), Error> {
+//     ) -> Result<()> {
 //         debug!("Validating object: {:?}", value);
 //         match value.as_mapping() {
 //             Some(mapping) => self.validate_object_mapping(context, mapping),
@@ -203,7 +204,7 @@ impl<'a> Engine<'a> {
 //         &self,
 //         context: &Context,
 //         mapping: &serde_yaml::Mapping,
-//     ) -> Result<(), Error> {
+//     ) -> Result<()> {
 //         for (k, value) in mapping {
 //             let key = match k {
 //                 serde_yaml::Value::String(s) => s.clone(),
@@ -299,7 +300,7 @@ impl<'a> Engine<'a> {
 //         &self,
 //         context: &Context,
 //         value: &serde_yaml::Value,
-//     ) -> Result<(), Error> {
+//     ) -> Result<()> {
 //         if !value.is_sequence() {
 //             context.add_error(format!("Expected an array, but got: {:?}", value));
 //             fail_fast!(context);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,9 +1,9 @@
 use log::debug;
 
 use super::validation::Validator;
-use crate::error::YamlSchemaError;
 pub use crate::validation::Context;
 pub use crate::validation::ValidationError;
+use crate::Error;
 use crate::YamlSchema;
 
 pub struct Engine<'a> {
@@ -15,18 +15,14 @@ impl<'a> Engine<'a> {
         Engine { schema }
     }
 
-    pub fn evaluate(
-        &self,
-        yaml: &serde_yaml::Value,
-        fail_fast: bool,
-    ) -> Result<Context, YamlSchemaError> {
+    pub fn evaluate(&self, yaml: &serde_yaml::Value, fail_fast: bool) -> Result<Context, Error> {
         debug!("Engine is running");
         let context = Context::new(fail_fast);
         let result = self.schema.validate(&context, yaml);
         debug!("Engine: result: {:?}", result);
         debug!("Engine: context.errors: {}", context.errors.borrow().len());
         match result {
-            Ok(()) | Err(YamlSchemaError::FailFast) => Ok(context),
+            Ok(()) | Err(Error::FailFast) => Ok(context),
             Err(e) => Err(e),
         }
     }
@@ -37,7 +33,7 @@ impl<'a> Engine<'a> {
 //         &self,
 //         context: &Context,
 //         value: &serde_yaml::Value,
-//     ) -> Result<(), YamlSchemaError> {
+//     ) -> Result<(), Error> {
 //         if !value.is_bool() {
 //             context.add_error(format!("Expected a boolean, but got: {:?}", value));
 //             fail_fast!(context);
@@ -162,7 +158,7 @@ impl<'a> Engine<'a> {
 //         &self,
 //         context: &Context,
 //         value: &serde_yaml::Value,
-//     ) -> Result<(), YamlSchemaError> {
+//     ) -> Result<(), Error> {
 //         match validate_string(
 //             self.min_length,
 //             self.max_length,
@@ -182,7 +178,7 @@ impl<'a> Engine<'a> {
 //             Err(e) => {
 //                 let s = e.to_string();
 //                 error!("{}", s);
-//                 Err(YamlSchemaError::GenericError(s))
+//                 Err(Error::GenericError(s))
 //             }
 //         }
 //     }
@@ -192,7 +188,7 @@ impl<'a> Engine<'a> {
 //         &self,
 //         context: &Context,
 //         value: &serde_yaml::Value,
-//     ) -> Result<(), YamlSchemaError> {
+//     ) -> Result<(), Error> {
 //         debug!("Validating object: {:?}", value);
 //         match value.as_mapping() {
 //             Some(mapping) => self.validate_object_mapping(context, mapping),
@@ -207,7 +203,7 @@ impl<'a> Engine<'a> {
 //         &self,
 //         context: &Context,
 //         mapping: &serde_yaml::Mapping,
-//     ) -> Result<(), YamlSchemaError> {
+//     ) -> Result<(), Error> {
 //         for (k, value) in mapping {
 //             let key = match k {
 //                 serde_yaml::Value::String(s) => s.clone(),
@@ -237,7 +233,7 @@ impl<'a> Engine<'a> {
 //                 for (pattern, schema) in pattern_properties {
 //                     // TODO: compile the regex once instead of every time we're evaluating
 //                     let re = regex::Regex::new(pattern).map_err(|e| {
-//                         YamlSchemaError::GenericError(format!(
+//                         Error::GenericError(format!(
 //                             "Invalid regular expression pattern: {}",
 //                             e
 //                         ))
@@ -250,14 +246,14 @@ impl<'a> Engine<'a> {
 //             // Finally, we check if it matches property_names
 //             if let Some(property_names) = &self.property_names {
 //                 let re = regex::Regex::new(&property_names.pattern).map_err(|e| {
-//                     YamlSchemaError::GenericError(format!(
+//                     Error::GenericError(format!(
 //                         "Invalid regular expression pattern: {}",
 //                         e
 //                     ))
 //                 })?;
 //                 debug!("Regex for property names: {}", re.as_str());
 //                 if !re.is_match(key.as_str()) {
-//                     return Err(YamlSchemaError::GenericError(format!(
+//                     return Err(Error::GenericError(format!(
 //                         "Property name '{}' does not match pattern specified in `propertyNames`!",
 //                         key
 //                     )));
@@ -269,7 +265,7 @@ impl<'a> Engine<'a> {
 //         if let Some(required) = &self.required {
 //             for required_property in required {
 //                 if !mapping.contains_key(required_property) {
-//                     return Err(YamlSchemaError::GenericError(format!(
+//                     return Err(Error::GenericError(format!(
 //                         "Required property '{}' is missing!",
 //                         required_property
 //                     )));
@@ -280,7 +276,7 @@ impl<'a> Engine<'a> {
 //         // Validate minProperties
 //         if let Some(min_properties) = &self.min_properties {
 //             if mapping.len() < *min_properties {
-//                 return Err(YamlSchemaError::GenericError(format!(
+//                 return Err(Error::GenericError(format!(
 //                     "Object has too few properties! Minimum is {}!",
 //                     min_properties
 //                 )));
@@ -289,7 +285,7 @@ impl<'a> Engine<'a> {
 //         // Validate maxProperties
 //         if let Some(max_properties) = &self.max_properties {
 //             if mapping.len() > *max_properties {
-//                 return Err(YamlSchemaError::GenericError(format!(
+//                 return Err(Error::GenericError(format!(
 //                     "Object has too many properties! Maximum is {}!",
 //                     max_properties
 //                 )));
@@ -303,7 +299,7 @@ impl<'a> Engine<'a> {
 //         &self,
 //         context: &Context,
 //         value: &serde_yaml::Value,
-//     ) -> Result<(), YamlSchemaError> {
+//     ) -> Result<(), Error> {
 //         if !value.is_sequence() {
 //             context.add_error(format!("Expected an array, but got: {:?}", value));
 //             fail_fast!(context);
@@ -323,7 +319,7 @@ impl<'a> Engine<'a> {
 //                 ArrayItemsValue::Boolean(true) => { /* no-op */ }
 //                 ArrayItemsValue::Boolean(false) => {
 //                     if self.prefix_items.is_none() {
-//                         return Err(YamlSchemaError::GenericError(
+//                         return Err(Error::GenericError(
 //                             "Array items are not allowed!".to_string(),
 //                         ));
 //                     }
@@ -337,7 +333,7 @@ impl<'a> Engine<'a> {
 //                 .iter()
 //                 .any(|item| contains.validate(context, item).is_ok())
 //             {
-//                 return Err(YamlSchemaError::GenericError(
+//                 return Err(Error::GenericError(
 //                     "Contains validation failed!".to_string(),
 //                 ));
 //             }
@@ -365,7 +361,7 @@ impl<'a> Engine<'a> {
 //                             break;
 //                         }
 //                         ArrayItemsValue::Boolean(false) => {
-//                             return Err(YamlSchemaError::GenericError(
+//                             return Err(Error::GenericError(
 //                                 "Additional array items are not allowed!".to_string(),
 //                             ));
 //                         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,7 +21,7 @@ pub enum Error {
 macro_rules! fail_fast {
     ($context:expr) => {
         if $context.fail_fast {
-            return Err(Error::FailFast);
+            return Err($crate::Error::FailFast);
         }
     };
 }
@@ -29,19 +29,19 @@ macro_rules! fail_fast {
 #[macro_export]
 macro_rules! unsupported_type {
     ($s:literal, $($e:expr),+) => {
-        Err(Error::UnsupportedType(format!($s, $($e),+)))
+        Err($crate::Error::UnsupportedType(format!($s, $($e),+)))
     };
     ($e:expr) => {
-        Err(Error::UnsupportedType($e))
+        Err($crate::Error::UnsupportedType($e))
     };
 }
 
 #[macro_export]
 macro_rules! generic_error {
     ($s:literal, $($e:expr),+) => {
-        Err(Error::GenericError(format!($s, $($e),+)))
+        Err($crate::Error::GenericError(format!($s, $($e),+)))
     };
     ($s:literal) => {
-        Error::GenericError($s.to_string())
+        $crate::Error::GenericError($s.to_string())
     };
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,11 +2,13 @@ use thiserror::Error;
 
 /// Unexpected errors that can occur during the validation of a YAML schema
 #[derive(Clone, Debug, Error, PartialEq)]
-pub enum YamlSchemaError {
+pub enum Error {
     #[error("Not yet implemented!")]
     NotYetImplemented,
     #[error("YAML parsing error: {0}")]
     YamlParsingError(#[from] yaml_rust2::ScanError),
+    #[error("Regex parsing error: {0}")]
+    RegexParsingError(#[from] regex::Error),
     #[error("Unsupported type: {0}")]
     UnsupportedType(String),
     #[error("Generic YAML schema error: {0}")]
@@ -19,7 +21,7 @@ pub enum YamlSchemaError {
 macro_rules! fail_fast {
     ($context:expr) => {
         if $context.fail_fast {
-            return Err(YamlSchemaError::FailFast);
+            return Err(Error::FailFast);
         }
     };
 }
@@ -27,19 +29,19 @@ macro_rules! fail_fast {
 #[macro_export]
 macro_rules! unsupported_type {
     ($s:literal, $($e:expr),+) => {
-        Err(YamlSchemaError::UnsupportedType(format!($s, $($e),+)))
+        Err(Error::UnsupportedType(format!($s, $($e),+)))
     };
     ($e:expr) => {
-        Err(YamlSchemaError::UnsupportedType($e))
+        Err(Error::UnsupportedType($e))
     };
 }
 
 #[macro_export]
 macro_rules! generic_error {
     ($s:literal, $($e:expr),+) => {
-        Err(YamlSchemaError::GenericError(format!($s, $($e),+)))
+        Err(Error::GenericError(format!($s, $($e),+)))
     };
     ($s:literal) => {
-        YamlSchemaError::GenericError($s.to_string())
+        Error::GenericError($s.to_string())
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,9 @@ pub fn version() -> String {
     clap::crate_version!().to_string()
 }
 
+// Alias for std::result::Result<T, yaml_schema::Error>
+pub type Result<T> = std::result::Result<T, Error>;
+
 /// A Number is either an integer or a float
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ pub mod schemas;
 pub mod validation;
 
 pub use engine::Engine;
-pub use error::YamlSchemaError;
+pub use error::Error;
 pub use schemas::{
     ArraySchema, ConstSchema, EnumSchema, IntegerSchema, NumberSchema, ObjectSchema, OneOfSchema,
     StringSchema,

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -1,6 +1,10 @@
 /// The schemas defined in the YAML schema language
 use std::fmt;
 
+use crate::Result;
+use crate::Validator;
+use crate::YamlSchema;
+
 mod any_of;
 mod array;
 mod bool_or_typed;
@@ -23,8 +27,6 @@ pub use one_of::OneOfSchema;
 pub use r#const::ConstSchema;
 pub use r#enum::EnumSchema;
 pub use string::StringSchema;
-
-use crate::{Validator, YamlSchema};
 
 #[derive(Debug, PartialEq)]
 pub enum TypedSchema {
@@ -70,11 +72,7 @@ impl fmt::Display for TypedSchema {
 }
 
 impl Validator for TypedSchema {
-    fn validate(
-        &self,
-        context: &crate::Context,
-        value: &serde_yaml::Value,
-    ) -> Result<(), crate::Error> {
+    fn validate(&self, context: &crate::Context, value: &serde_yaml::Value) -> Result<()> {
         match self {
             TypedSchema::Array(a) => a.validate(context, value),
             TypedSchema::Boolean => Ok(()),

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -74,7 +74,7 @@ impl Validator for TypedSchema {
         &self,
         context: &crate::Context,
         value: &serde_yaml::Value,
-    ) -> Result<(), crate::YamlSchemaError> {
+    ) -> Result<(), crate::Error> {
         match self {
             TypedSchema::Array(a) => a.validate(context, value),
             TypedSchema::Boolean => Ok(()),

--- a/src/schemas/array.rs
+++ b/src/schemas/array.rs
@@ -1,11 +1,14 @@
 use log::debug;
 use std::fmt;
 
-use super::BoolOrTypedSchema;
 use crate::deser::Deser;
+use crate::deser_typed_schema;
 use crate::format_vec;
-use crate::validation::Validator;
-use crate::{deser_typed_schema, Error, YamlSchema};
+use crate::Result;
+use crate::Validator;
+use crate::YamlSchema;
+
+use super::BoolOrTypedSchema;
 
 /// An array schema represents an array
 #[derive(Debug, PartialEq)]
@@ -49,11 +52,7 @@ impl From<&crate::deser::TypedSchema> for ArraySchema {
 }
 
 impl Validator for ArraySchema {
-    fn validate(
-        &self,
-        context: &crate::Context,
-        value: &serde_yaml::Value,
-    ) -> Result<(), crate::Error> {
+    fn validate(&self, context: &crate::Context, value: &serde_yaml::Value) -> Result<()> {
         if !value.is_sequence() {
             context.add_error(format!("Expected an array, but got: {:?}", value));
             fail_fast!(context);

--- a/src/schemas/array.rs
+++ b/src/schemas/array.rs
@@ -5,7 +5,7 @@ use super::BoolOrTypedSchema;
 use crate::deser::Deser;
 use crate::format_vec;
 use crate::validation::Validator;
-use crate::{deser_typed_schema, YamlSchema, YamlSchemaError};
+use crate::{deser_typed_schema, Error, YamlSchema};
 
 /// An array schema represents an array
 #[derive(Debug, PartialEq)]
@@ -53,7 +53,7 @@ impl Validator for ArraySchema {
         &self,
         context: &crate::Context,
         value: &serde_yaml::Value,
-    ) -> Result<(), crate::YamlSchemaError> {
+    ) -> Result<(), crate::Error> {
         if !value.is_sequence() {
             context.add_error(format!("Expected an array, but got: {:?}", value));
             fail_fast!(context);

--- a/src/schemas/boolean.rs
+++ b/src/schemas/boolean.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self};
 
-use crate::Error;
+use crate::Result;
 use crate::Validator;
 
 /// A boolean schema matches any boolean value
@@ -30,7 +30,7 @@ impl Validator for BooleanSchema {
         &self,
         context: &crate::validation::Context,
         value: &serde_yaml::Value,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         if !value.is_bool() {
             context.add_error(format!("Expected: boolean, found: {:?}", value));
         }

--- a/src/schemas/boolean.rs
+++ b/src/schemas/boolean.rs
@@ -1,5 +1,6 @@
 use std::fmt::{self};
 
+use crate::Error;
 use crate::Validator;
 
 /// A boolean schema matches any boolean value
@@ -29,7 +30,7 @@ impl Validator for BooleanSchema {
         &self,
         context: &crate::validation::Context,
         value: &serde_yaml::Value,
-    ) -> Result<(), crate::error::YamlSchemaError> {
+    ) -> Result<(), Error> {
         if !value.is_bool() {
             context.add_error(format!("Expected: boolean, found: {:?}", value));
         }

--- a/src/schemas/integer.rs
+++ b/src/schemas/integer.rs
@@ -2,8 +2,8 @@ use std::fmt;
 
 use crate::validation::Context;
 use crate::validation::Validator;
+use crate::Error;
 use crate::Number;
-use crate::YamlSchemaError;
 
 /// A number schema
 #[derive(Debug, Default, PartialEq)]
@@ -22,11 +22,7 @@ impl fmt::Display for IntegerSchema {
 }
 
 impl Validator for IntegerSchema {
-    fn validate(
-        &self,
-        context: &Context,
-        value: &serde_yaml::Value,
-    ) -> Result<(), YamlSchemaError> {
+    fn validate(&self, context: &Context, value: &serde_yaml::Value) -> Result<(), Error> {
         match value.as_i64() {
             Some(i) => self.validate_number_i64(context, i),
             None => {

--- a/src/schemas/integer.rs
+++ b/src/schemas/integer.rs
@@ -2,8 +2,8 @@ use std::fmt;
 
 use crate::validation::Context;
 use crate::validation::Validator;
-use crate::Error;
 use crate::Number;
+use crate::Result;
 
 /// A number schema
 #[derive(Debug, Default, PartialEq)]
@@ -22,7 +22,7 @@ impl fmt::Display for IntegerSchema {
 }
 
 impl Validator for IntegerSchema {
-    fn validate(&self, context: &Context, value: &serde_yaml::Value) -> Result<(), Error> {
+    fn validate(&self, context: &Context, value: &serde_yaml::Value) -> Result<()> {
         match value.as_i64() {
             Some(i) => self.validate_number_i64(context, i),
             None => {

--- a/src/schemas/number.rs
+++ b/src/schemas/number.rs
@@ -2,8 +2,8 @@ use std::fmt;
 
 use crate::validation::Context;
 use crate::validation::Validator;
+use crate::Error;
 use crate::Number;
-use crate::YamlSchemaError;
 
 /// A number schema
 #[derive(Debug, Default, PartialEq)]
@@ -22,11 +22,7 @@ impl fmt::Display for NumberSchema {
 }
 
 impl Validator for NumberSchema {
-    fn validate(
-        &self,
-        context: &Context,
-        value: &serde_yaml::Value,
-    ) -> Result<(), YamlSchemaError> {
+    fn validate(&self, context: &Context, value: &serde_yaml::Value) -> Result<(), Error> {
         if value.is_i64() {
             match value.as_i64() {
                 Some(i) => self.validate_number_i64(context, i),

--- a/src/schemas/number.rs
+++ b/src/schemas/number.rs
@@ -2,8 +2,8 @@ use std::fmt;
 
 use crate::validation::Context;
 use crate::validation::Validator;
-use crate::Error;
 use crate::Number;
+use crate::Result;
 
 /// A number schema
 #[derive(Debug, Default, PartialEq)]
@@ -22,7 +22,7 @@ impl fmt::Display for NumberSchema {
 }
 
 impl Validator for NumberSchema {
-    fn validate(&self, context: &Context, value: &serde_yaml::Value) -> Result<(), Error> {
+    fn validate(&self, context: &Context, value: &serde_yaml::Value) -> Result<()> {
         if value.is_i64() {
             match value.as_i64() {
                 Some(i) => self.validate_number_i64(context, i),

--- a/src/schemas/object.rs
+++ b/src/schemas/object.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use super::BoolOrTypedSchema;
 use crate::validation::objects::try_validate_value_against_additional_properties;
 use crate::validation::objects::try_validate_value_against_properties;
+use crate::Result;
 use crate::{Context, Error, PropertyNamesValue, Validator, YamlSchema};
 
 /// An object schema
@@ -27,7 +28,7 @@ impl fmt::Display for ObjectSchema {
 
 impl Validator for ObjectSchema {
     /// Validate the object according to the schema rules
-    fn validate(&self, context: &Context, value: &serde_yaml::Value) -> Result<(), Error> {
+    fn validate(&self, context: &Context, value: &serde_yaml::Value) -> Result<()> {
         debug!("Validating object: {:?}", value);
         match value.as_mapping() {
             Some(mapping) => self.validate_object_mapping(context, mapping),
@@ -44,7 +45,7 @@ impl ObjectSchema {
         &self,
         context: &Context,
         mapping: &serde_yaml::Mapping,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         for (k, value) in mapping {
             let key = match k {
                 serde_yaml::Value::String(s) => s.clone(),

--- a/src/schemas/string.rs
+++ b/src/schemas/string.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::{validation::strings::validate_string, Context, Validator, YamlSchemaError};
+use crate::{validation::strings::validate_string, Context, Error, Validator};
 
 /// A string schema
 #[derive(Debug, PartialEq, Default)]
@@ -17,11 +17,7 @@ impl fmt::Display for StringSchema {
 }
 
 impl Validator for StringSchema {
-    fn validate(
-        &self,
-        context: &Context,
-        value: &serde_yaml::Value,
-    ) -> Result<(), YamlSchemaError> {
+    fn validate(&self, context: &Context, value: &serde_yaml::Value) -> Result<(), Error> {
         match validate_string(
             self.min_length,
             self.max_length,

--- a/src/schemas/string.rs
+++ b/src/schemas/string.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
-use crate::{validation::strings::validate_string, Context, Error, Validator};
+use crate::Result;
+use crate::{validation::strings::validate_string, Context, Validator};
 
 /// A string schema
 #[derive(Debug, PartialEq, Default)]
@@ -17,7 +18,7 @@ impl fmt::Display for StringSchema {
 }
 
 impl Validator for StringSchema {
-    fn validate(&self, context: &Context, value: &serde_yaml::Value) -> Result<(), Error> {
+    fn validate(&self, context: &Context, value: &serde_yaml::Value) -> Result<()> {
         match validate_string(
             self.min_length,
             self.max_length,

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -10,11 +10,16 @@ pub use context::Context;
 use log::{debug, error};
 use one_of::validate_one_of;
 
-use crate::{format_serde_yaml_value, ConstSchema, EnumSchema, Error, OneOfSchema, YamlSchema};
+use crate::format_serde_yaml_value;
+use crate::ConstSchema;
+use crate::EnumSchema;
+use crate::OneOfSchema;
+use crate::Result;
+use crate::YamlSchema;
 
 /// A trait for validating a value against a schema
 pub trait Validator {
-    fn validate(&self, context: &Context, value: &serde_yaml::Value) -> Result<(), Error>;
+    fn validate(&self, context: &Context, value: &serde_yaml::Value) -> Result<()>;
 }
 
 /// A validation error simply contains a path and an error message
@@ -34,7 +39,7 @@ impl Display for ValidationError {
 }
 
 impl Validator for ConstSchema {
-    fn validate(&self, context: &Context, value: &serde_yaml::Value) -> Result<(), Error> {
+    fn validate(&self, context: &Context, value: &serde_yaml::Value) -> Result<()> {
         debug!(
             "Validating value: {:?} against const: {:?}",
             value, self.r#const
@@ -52,7 +57,7 @@ impl Validator for ConstSchema {
 }
 
 impl Validator for EnumSchema {
-    fn validate(&self, context: &Context, value: &serde_yaml::Value) -> Result<(), Error> {
+    fn validate(&self, context: &Context, value: &serde_yaml::Value) -> Result<()> {
         if !self.r#enum.contains(value) {
             let value_str = format_serde_yaml_value(value);
             let enum_values = self
@@ -69,7 +74,7 @@ impl Validator for EnumSchema {
 }
 
 impl Validator for OneOfSchema {
-    fn validate(&self, context: &Context, value: &serde_yaml::Value) -> Result<(), Error> {
+    fn validate(&self, context: &Context, value: &serde_yaml::Value) -> Result<()> {
         let one_of_is_valid = validate_one_of(context, &self.one_of, value)?;
         if !one_of_is_valid {
             error!("OneOf: None of the schemas in `oneOf` matched!");
@@ -81,7 +86,7 @@ impl Validator for OneOfSchema {
 }
 
 impl Validator for YamlSchema {
-    fn validate(&self, context: &Context, value: &serde_yaml::Value) -> Result<(), Error> {
+    fn validate(&self, context: &Context, value: &serde_yaml::Value) -> Result<()> {
         debug!("YamlSchema: self: {}", self);
         debug!("YamlSchema: Validating value: {:?}", value);
         match self {

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -10,14 +10,11 @@ pub use context::Context;
 use log::{debug, error};
 use one_of::validate_one_of;
 
-use crate::{
-    format_serde_yaml_value, ConstSchema, EnumSchema, OneOfSchema, YamlSchema, YamlSchemaError,
-};
+use crate::{format_serde_yaml_value, ConstSchema, EnumSchema, Error, OneOfSchema, YamlSchema};
 
 /// A trait for validating a value against a schema
 pub trait Validator {
-    fn validate(&self, context: &Context, value: &serde_yaml::Value)
-        -> Result<(), YamlSchemaError>;
+    fn validate(&self, context: &Context, value: &serde_yaml::Value) -> Result<(), Error>;
 }
 
 /// A validation error simply contains a path and an error message
@@ -37,11 +34,7 @@ impl Display for ValidationError {
 }
 
 impl Validator for ConstSchema {
-    fn validate(
-        &self,
-        context: &Context,
-        value: &serde_yaml::Value,
-    ) -> Result<(), YamlSchemaError> {
+    fn validate(&self, context: &Context, value: &serde_yaml::Value) -> Result<(), Error> {
         debug!(
             "Validating value: {:?} against const: {:?}",
             value, self.r#const
@@ -59,11 +52,7 @@ impl Validator for ConstSchema {
 }
 
 impl Validator for EnumSchema {
-    fn validate(
-        &self,
-        context: &Context,
-        value: &serde_yaml::Value,
-    ) -> Result<(), YamlSchemaError> {
+    fn validate(&self, context: &Context, value: &serde_yaml::Value) -> Result<(), Error> {
         if !self.r#enum.contains(value) {
             let value_str = format_serde_yaml_value(value);
             let enum_values = self
@@ -80,11 +69,7 @@ impl Validator for EnumSchema {
 }
 
 impl Validator for OneOfSchema {
-    fn validate(
-        &self,
-        context: &Context,
-        value: &serde_yaml::Value,
-    ) -> Result<(), YamlSchemaError> {
+    fn validate(&self, context: &Context, value: &serde_yaml::Value) -> Result<(), Error> {
         let one_of_is_valid = validate_one_of(context, &self.one_of, value)?;
         if !one_of_is_valid {
             error!("OneOf: None of the schemas in `oneOf` matched!");
@@ -96,11 +81,7 @@ impl Validator for OneOfSchema {
 }
 
 impl Validator for YamlSchema {
-    fn validate(
-        &self,
-        context: &Context,
-        value: &serde_yaml::Value,
-    ) -> Result<(), YamlSchemaError> {
+    fn validate(&self, context: &Context, value: &serde_yaml::Value) -> Result<(), Error> {
         debug!("YamlSchema: self: {}", self);
         debug!("YamlSchema: Validating value: {:?}", value);
         match self {

--- a/src/validation/objects.rs
+++ b/src/validation/objects.rs
@@ -5,14 +5,15 @@ use std::collections::HashMap;
 use super::Validator;
 use crate::schemas::BoolOrTypedSchema;
 use crate::validation::Context;
-use crate::{Error, YamlSchema};
+use crate::Result;
+use crate::YamlSchema;
 
 pub fn try_validate_value_against_properties(
     context: &Context,
     key: &String,
     value: &serde_yaml::Value,
     properties: &HashMap<String, YamlSchema>,
-) -> Result<bool, Error> {
+) -> Result<bool> {
     let sub_context = context.append_path(key);
     if let Some(schema) = properties.get(key) {
         debug!("Validating property '{}' with schema: {}", key, schema);
@@ -33,7 +34,7 @@ pub fn try_validate_value_against_additional_properties(
     key: &String,
     value: &serde_yaml::Value,
     additional_properties: &BoolOrTypedSchema,
-) -> Result<bool, Error> {
+) -> Result<bool> {
     let sub_context = context.append_path(key);
 
     match additional_properties {

--- a/src/validation/objects.rs
+++ b/src/validation/objects.rs
@@ -5,14 +5,14 @@ use std::collections::HashMap;
 use super::Validator;
 use crate::schemas::BoolOrTypedSchema;
 use crate::validation::Context;
-use crate::{YamlSchema, YamlSchemaError};
+use crate::{Error, YamlSchema};
 
 pub fn try_validate_value_against_properties(
     context: &Context,
     key: &String,
     value: &serde_yaml::Value,
     properties: &HashMap<String, YamlSchema>,
-) -> Result<bool, YamlSchemaError> {
+) -> Result<bool, Error> {
     let sub_context = context.append_path(key);
     if let Some(schema) = properties.get(key) {
         debug!("Validating property '{}' with schema: {}", key, schema);
@@ -33,7 +33,7 @@ pub fn try_validate_value_against_additional_properties(
     key: &String,
     value: &serde_yaml::Value,
     additional_properties: &BoolOrTypedSchema,
-) -> Result<bool, YamlSchemaError> {
+) -> Result<bool, Error> {
     let sub_context = context.append_path(key);
 
     match additional_properties {

--- a/src/validation/one_of.rs
+++ b/src/validation/one_of.rs
@@ -1,12 +1,12 @@
 use super::Validator;
-use crate::{Context, YamlSchema, YamlSchemaError};
+use crate::{Context, Error, YamlSchema};
 use log::{debug, error};
 
 pub fn validate_one_of(
     context: &Context,
     schemas: &Vec<YamlSchema>,
     value: &serde_yaml::Value,
-) -> Result<bool, YamlSchemaError> {
+) -> Result<bool, Error> {
     let mut one_of_is_valid = false;
     for schema in schemas {
         debug!(
@@ -16,7 +16,7 @@ pub fn validate_one_of(
         let sub_context = Context::new(context.fail_fast);
         let sub_result = schema.validate(&sub_context, value);
         match sub_result {
-            Ok(()) | Err(YamlSchemaError::FailFast) => {
+            Ok(()) | Err(Error::FailFast) => {
                 debug!(
                     "OneOf: sub_context.errors: {}",
                     sub_context.errors.borrow().len()

--- a/src/validation/one_of.rs
+++ b/src/validation/one_of.rs
@@ -1,12 +1,15 @@
 use super::Validator;
-use crate::{Context, Error, YamlSchema};
+use crate::Context;
+use crate::Error;
+use crate::Result;
+use crate::YamlSchema;
 use log::{debug, error};
 
 pub fn validate_one_of(
     context: &Context,
     schemas: &Vec<YamlSchema>,
     value: &serde_yaml::Value,
-) -> Result<bool, Error> {
+) -> Result<bool> {
     let mut one_of_is_valid = false;
     for schema in schemas {
         debug!(

--- a/src/validation/strings.rs
+++ b/src/validation/strings.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use crate::Error;
 
 /// Just trying to isolate the actual validation into a function that doesn't take a context
 pub fn validate_string(
@@ -6,7 +6,7 @@ pub fn validate_string(
     max_length: Option<usize>,
     pattern: Option<&String>,
     value: &serde_yaml::Value,
-) -> Result<Vec<String>> {
+) -> Result<Vec<String>, Error> {
     let mut errors = Vec::new();
     let yaml_string = match value.as_str() {
         Some(s) => s,

--- a/src/validation/strings.rs
+++ b/src/validation/strings.rs
@@ -1,4 +1,4 @@
-use crate::Error;
+use crate::Result;
 
 /// Just trying to isolate the actual validation into a function that doesn't take a context
 pub fn validate_string(
@@ -6,7 +6,7 @@ pub fn validate_string(
     max_length: Option<usize>,
     pattern: Option<&String>,
     value: &serde_yaml::Value,
-) -> Result<Vec<String>, Error> {
+) -> Result<Vec<String>> {
     let mut errors = Vec::new();
     let yaml_string = match value.as_str() {
         Some(s) => s,

--- a/tests/basics.rs
+++ b/tests/basics.rs
@@ -9,7 +9,7 @@ use yaml_schema::{Engine, YamlSchema};
 #[derive(Debug, Default, World)]
 pub struct BasicsWorld {
     yaml_schema: YamlSchema,
-    yaml_schema_error: Option<yaml_schema::YamlSchemaError>,
+    yaml_schema_error: Option<yaml_schema::Error>,
     errors: Option<Rc<RefCell<Vec<ValidationError>>>>,
 }
 
@@ -88,15 +88,15 @@ fn the_error_message_should_be(world: &mut BasicsWorld, expected_error_message: 
 async fn it_should_fail_with(world: &mut BasicsWorld, expected_error_message: String) {
     if let Some(yaml_schema_error) = world.yaml_schema_error.as_ref() {
         match yaml_schema_error {
-            yaml_schema::YamlSchemaError::GenericError(actual_error_message) => {
+            yaml_schema::Error::GenericError(actual_error_message) => {
                 debug!("expected_error_message: {:?}", expected_error_message);
                 debug!("actual_error_message: {:?}", actual_error_message);
                 assert_eq!(expected_error_message, *actual_error_message)
             }
-            yaml_schema::YamlSchemaError::NotYetImplemented => {
+            yaml_schema::Error::NotYetImplemented => {
                 assert_eq!(expected_error_message, "a NotYetImplemented error");
             }
-            yaml_schema::YamlSchemaError::UnsupportedType(actual_error_message) => {
+            yaml_schema::Error::UnsupportedType(actual_error_message) => {
                 assert_eq!(expected_error_message, *actual_error_message)
             }
             _ => panic!("Unexpected error: {:?}", yaml_schema_error),


### PR DESCRIPTION
## Why?

Result and error-handling is getting messy and complicated.

## What?

- Replace `anyhow` with `eyre`
- Use `eyre` in the `ys` binary code
- Rename `YamlSchemaError` into simply `Error`
- Introduce a `Result` type (that's just `std::result::Result<T, Error>` and use it everywhere
