### PR TITLE
Aarch64-apple-darwin release plan

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let target = std::env::var("TARGET").unwrap_or_else(|_| "unknown".to_string());
+    println!("cargo:rustc-env=YS_TARGET={target}");
+}

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -6,10 +6,7 @@ Feature: CLI usage
       ys version
       ```
     Then it should exit with status code 0
-    And it should output:
-      ```
-      ys 0.9.0
-      ```
+    And the output should start with "ys 0.9.0"
 
   Scenario: Basic validation with a valid file
     When the following command is run:

--- a/src/bin/ys.rs
+++ b/src/bin/ys.rs
@@ -15,7 +15,7 @@ use yaml_schema::version;
 #[derive(Parser, Debug, Default)]
 #[command(name = "ys")]
 #[command(author = "Alistair Israel <aisrael@gmail.com>")]
-#[command(version = clap::crate_version!())]
+#[command(version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("YS_TARGET"), ")"))]
 #[command(about = "A tool for validating YAML against a schema")]
 #[command(arg_required_else_help = true)]
 pub struct Opts {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod engine;
 pub mod loader;
 pub mod reference;
 pub mod schemas;
+pub mod target;
 pub mod utils;
 pub mod validation;
 
@@ -27,9 +28,11 @@ use utils::format_marker;
 
 use crate::loader::marked_yaml_to_string;
 
-// Returns the library version, which reflects the crate version
+/// Returns the library version string including the target triple.
+///
+/// Format: `{crate_version} ({target_triple})`
 pub fn version() -> String {
-    clap::crate_version!().to_string()
+    format!("{} ({})", clap::crate_version!(), target::TARGET)
 }
 
 // Alias for std::result::Result<T, yaml_schema::Error>

--- a/src/target.rs
+++ b/src/target.rs
@@ -1,0 +1,195 @@
+use std::fmt;
+
+/// The target triple this binary was compiled for, captured at build time.
+pub const TARGET: &str = env!("YS_TARGET");
+
+/// The architecture component of a target triple (e.g., `aarch64`, `x86_64`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Arch {
+    Aarch64,
+    X86_64,
+    Arm,
+    Armv7,
+    Other,
+}
+
+impl Arch {
+    fn parse(s: &str) -> Self {
+        match s {
+            "aarch64" => Arch::Aarch64,
+            "x86_64" => Arch::X86_64,
+            "arm" => Arch::Arm,
+            "armv7" => Arch::Armv7,
+            _ => Arch::Other,
+        }
+    }
+}
+
+impl fmt::Display for Arch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Arch::Aarch64 => write!(f, "aarch64"),
+            Arch::X86_64 => write!(f, "x86_64"),
+            Arch::Arm => write!(f, "arm"),
+            Arch::Armv7 => write!(f, "armv7"),
+            Arch::Other => write!(f, "unknown"),
+        }
+    }
+}
+
+/// The operating system component of a target triple (e.g., `darwin`, `linux`, `windows`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Os {
+    Darwin,
+    Linux,
+    Windows,
+    Other,
+}
+
+impl Os {
+    fn parse(s: &str) -> Self {
+        if s.contains("darwin") {
+            Os::Darwin
+        } else if s.contains("linux") {
+            Os::Linux
+        } else if s.contains("windows") {
+            Os::Windows
+        } else {
+            Os::Other
+        }
+    }
+}
+
+impl fmt::Display for Os {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Os::Darwin => write!(f, "macOS"),
+            Os::Linux => write!(f, "Linux"),
+            Os::Windows => write!(f, "Windows"),
+            Os::Other => write!(f, "unknown"),
+        }
+    }
+}
+
+/// A parsed Rust target triple (e.g., `aarch64-apple-darwin`).
+///
+/// Represents the architecture, vendor, and OS extracted from the full triple string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Target {
+    pub triple: String,
+    pub arch: Arch,
+    pub os: Os,
+}
+
+impl Target {
+    /// Parse a target triple string into its components.
+    ///
+    /// ```
+    /// use yaml_schema::target::Target;
+    /// use yaml_schema::target::Arch;
+    /// use yaml_schema::target::Os;
+    ///
+    /// let target = Target::parse("aarch64-apple-darwin");
+    /// assert_eq!(target.arch, Arch::Aarch64);
+    /// assert_eq!(target.os, Os::Darwin);
+    /// assert_eq!(target.triple, "aarch64-apple-darwin");
+    /// ```
+    pub fn parse(triple: &str) -> Self {
+        let parts: Vec<&str> = triple.splitn(4, '-').collect();
+        let arch = Arch::parse(parts.first().unwrap_or(&""));
+        let os_str = parts.get(2).unwrap_or(&"");
+        let os = Os::parse(os_str);
+
+        Target {
+            triple: triple.to_string(),
+            arch,
+            os,
+        }
+    }
+
+    /// Returns the target triple this binary was compiled for.
+    pub fn current() -> Self {
+        Self::parse(TARGET)
+    }
+
+    /// Returns true if this target is a macOS (Darwin) target.
+    pub fn is_macos(&self) -> bool {
+        self.os == Os::Darwin
+    }
+
+    /// Returns true if this target is an Apple Silicon (aarch64 + Darwin) target.
+    pub fn is_apple_silicon(&self) -> bool {
+        self.arch == Arch::Aarch64 && self.os == Os::Darwin
+    }
+}
+
+impl fmt::Display for Target {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.triple)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_aarch64_apple_darwin() {
+        let target = Target::parse("aarch64-apple-darwin");
+        assert_eq!(target.arch, Arch::Aarch64);
+        assert_eq!(target.os, Os::Darwin);
+        assert_eq!(target.triple, "aarch64-apple-darwin");
+        assert!(target.is_macos());
+        assert!(target.is_apple_silicon());
+    }
+
+    #[test]
+    fn test_parse_x86_64_apple_darwin() {
+        let target = Target::parse("x86_64-apple-darwin");
+        assert_eq!(target.arch, Arch::X86_64);
+        assert_eq!(target.os, Os::Darwin);
+        assert!(target.is_macos());
+        assert!(!target.is_apple_silicon());
+    }
+
+    #[test]
+    fn test_parse_x86_64_unknown_linux_gnu() {
+        let target = Target::parse("x86_64-unknown-linux-gnu");
+        assert_eq!(target.arch, Arch::X86_64);
+        assert_eq!(target.os, Os::Linux);
+        assert!(!target.is_macos());
+    }
+
+    #[test]
+    fn test_parse_x86_64_pc_windows_msvc() {
+        let target = Target::parse("x86_64-pc-windows-msvc");
+        assert_eq!(target.arch, Arch::X86_64);
+        assert_eq!(target.os, Os::Windows);
+        assert!(!target.is_macos());
+    }
+
+    #[test]
+    fn test_display() {
+        let target = Target::parse("aarch64-apple-darwin");
+        assert_eq!(format!("{target}"), "aarch64-apple-darwin");
+    }
+
+    #[test]
+    fn test_current_target() {
+        let target = Target::current();
+        assert!(!target.triple.is_empty());
+    }
+
+    #[test]
+    fn test_os_display() {
+        assert_eq!(format!("{}", Os::Darwin), "macOS");
+        assert_eq!(format!("{}", Os::Linux), "Linux");
+        assert_eq!(format!("{}", Os::Windows), "Windows");
+    }
+
+    #[test]
+    fn test_arch_display() {
+        assert_eq!(format!("{}", Arch::Aarch64), "aarch64");
+        assert_eq!(format!("{}", Arch::X86_64), "x86_64");
+    }
+}

--- a/tests/features.rs
+++ b/tests/features.rs
@@ -146,6 +146,19 @@ async fn it_should_output(world: &mut FeaturesWorld, step: &Step) {
     assert_eq!(actual, expected, "stdout mismatch");
 }
 
+#[then(expr = "the output should start with {string}")]
+async fn the_output_should_start_with(world: &mut FeaturesWorld, prefix: String) {
+    let output = world
+        .command_output
+        .as_ref()
+        .expect("No command has been run");
+    let actual = output.stdout.trim();
+    assert!(
+        actual.starts_with(&prefix),
+        "Expected stdout to start with:\n{prefix}\nBut got:\n{actual}"
+    );
+}
+
 #[then(regex = "stderr output should end with:")]
 async fn stderr_output_should_end_with(world: &mut FeaturesWorld, step: &Step) {
     let expected = step.docstring().expect("Expected a docstring");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Represent the target triple in the codebase and update version output to prepare for platform-specific binary distribution.

<div><a href="https://cursor.com/agents/bc-aa9b50fb-78ed-4f31-9593-dd598b92a7ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa9b50fb-78ed-4f31-9593-dd598b92a7ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->