### PR TITLE
Object validation: apply both properties and patternProperties (JSON Schema 2020-12)

### DIFF
--- a/features/validation/objects.feature
+++ b/features/validation/objects.feature
@@ -240,6 +240,29 @@ Feature: Object types
       whatever: 21
       ```
 
+  Scenario: properties and patternProperties both apply to the same key
+    Given a YAML schema:
+      ```
+      type: object
+      properties:
+        foo:
+          type: number
+          minimum: 0
+      patternProperties:
+        ^f:
+          type: number
+          maximum: 10
+      additionalProperties: false
+      ```
+    Then it should accept:
+      ```
+      foo: 5
+      ```
+    But it should NOT accept:
+      ```
+      foo: 50
+      ```
+
   Scenario: additionalProperties as a object schemas with unused properties
     Given a YAML schema:
       ```

--- a/src/validation/objects.rs
+++ b/src/validation/objects.rs
@@ -116,27 +116,29 @@ impl ObjectSchema {
                 continue;
             }
 
-            // First, we check the explicitly defined properties, and validate against it if found
-            if let Some(properties) = &self.properties
-                && try_validate_value_against_properties(context, &key_string, value, properties)?
-            {
-                continue;
-            }
+            // `properties` and `patternProperties` both apply when they match (JSON Schema 2020-12).
+            let covered_by_properties = if let Some(properties) = &self.properties {
+                try_validate_value_against_properties(context, &key_string, value, properties)?
+            } else {
+                false
+            };
 
             let mut matched_pattern_property = false;
             if let Some(pattern_properties) = &self.pattern_properties {
+                let pattern_context = context.append_path(&key_string);
                 for pp in pattern_properties {
                     log::debug!("pattern: {}", pp.regex.as_str());
                     if pp.regex.is_match(key_string.as_ref()) {
                         matched_pattern_property = true;
-                        pp.schema.validate(context, value)?;
+                        pp.schema.validate(&pattern_context, value)?;
                     }
                 }
             }
 
-            // additionalProperties only applies when a property does not match
-            // either explicit properties or patternProperties.
-            if !matched_pattern_property
+            // additionalProperties applies only when the name is not in `properties` and matches
+            // no `patternProperties` regex (JSON Schema 2020-12).
+            if !covered_by_properties
+                && !matched_pattern_property
                 && let Some(additional_properties) = &self.additional_properties
             {
                 try_validate_value_against_additional_properties(


### PR DESCRIPTION
## Summary

Aligns object validation with JSON Schema 2020-12: when a property name matches both `properties` and `patternProperties`, the instance value is validated against **both** subschemas.

- **Before:** `properties` short-circuited; pattern properties were skipped for the same key.
- **After:** Both schemas run; `additionalProperties` applies only when the name is not listed in `properties` and matches no `patternProperties` regex.

Pattern-property validation now uses `context.append_path` so errors reference the correct property path.

## Key changes

- `src/validation/objects.rs`: validate both explicit and pattern properties; path context for pattern rules
- `features/validation/objects.feature`: Cucumber scenario covering overlapping `foo` and `^f`

Made with [Cursor](https://cursor.com)