### PR TITLE
fix: use Unicode scalar count for minLength/maxLength

### DIFF
--- a/features/validation/strings.feature
+++ b/features/validation/strings.feature
@@ -46,6 +46,21 @@ Feature: String validation
       "ABCD"
       ```
 
+  Scenario: length counts Unicode characters not UTF-8 bytes
+    Given a YAML schema:
+      ```
+      type: string
+      maxLength: 2
+      ```
+    Then it should accept:
+      ```
+      "αβ"
+      ```
+    But it should NOT accept:
+      ```
+      "αβγ"
+      ```
+
   Scenario: pattern validation
     Given a YAML schema:
       ```

--- a/src/validation/strings.rs
+++ b/src/validation/strings.rs
@@ -57,13 +57,19 @@ pub fn validate_string(
     r#enum: Option<&Vec<String>>,
     str_value: &str,
 ) {
-    if let Some(min_length) = min_length
-        && str_value.len() < min_length
+    // JSON Schema string length is the number of Unicode scalar values (JSON / RFC 8259
+    // "characters"), not UTF-8 byte length.
+    let char_len =
+        (min_length.is_some() || max_length.is_some()).then(|| str_value.chars().count());
+    if let Some(n) = char_len
+        && let Some(min_length) = min_length
+        && n < min_length
     {
         errors.push(format!("String is too short! (min length: {min_length})"));
     }
-    if let Some(max_length) = max_length
-        && str_value.len() > max_length
+    if let Some(n) = char_len
+        && let Some(max_length) = max_length
+        && n > max_length
     {
         errors.push(format!("String is too long! (max length: {max_length})"));
     }
@@ -134,6 +140,33 @@ mod tests {
         assert_eq!(
             errors.first().unwrap(),
             "String is too short! (min length: 5)"
+        );
+    }
+
+    /// `minLength` / `maxLength` count Unicode scalars, not UTF-8 bytes (JSON Schema).
+    #[test]
+    fn test_validate_string_length_counts_unicode_scalars_not_utf8_bytes() {
+        // Three Greek letters: 3 characters, 6 UTF-8 bytes.
+        let greek = "αβγ";
+        assert_eq!(greek.len(), 6);
+        assert_eq!(greek.chars().count(), 3);
+
+        let mut errors = Vec::new();
+        validate_string(&mut errors, None, Some(3), None, None, None, greek);
+        assert!(
+            errors.is_empty(),
+            "maxLength 3 must allow three characters (not three bytes)"
+        );
+
+        let mut errors = Vec::new();
+        validate_string(&mut errors, None, Some(2), None, None, None, greek);
+        assert_eq!(errors.len(), 1);
+
+        let mut errors = Vec::new();
+        validate_string(&mut errors, Some(4), None, None, None, None, greek);
+        assert_eq!(
+            errors.first().map(|s| s.as_str()),
+            Some("String is too short! (min length: 4)")
         );
     }
 


### PR DESCRIPTION
## Summary
`minLength` / `maxLength` now follow JSON Schema semantics: length is the number of **Unicode scalar values** (JSON string "characters"), not UTF-8 byte length.

## Changes
- **`validate_string`** (`src/validation/strings.rs`): compute `str_value.chars().count()` once when either bound is present.
- **Unit test** with multi-byte Greek text (`αβγ`).
- **Cucumber** scenario in `features/validation/strings.feature` (`maxLength: 2` vs `αβ` / `αβγ`).

## Why
Non-ASCII strings were incorrectly rejected or accepted when limits were between byte count and character count (e.g. three Greek letters = 3 chars but 6 bytes).

Made with [Cursor](https://cursor.com)