### PR TITLE
feat: unevaluatedProperties and unevaluatedItems validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Should fail with exit code 1
 - [Object types](features/validation/objects.feature)
 - [Arrays](features/validation/arrays.feature)
 - [Composition](features/composition.feature)
+- [Unevaluated properties/items](features/validation/unevaluated.feature)
 
 See the [features](features/) folder for all examples.
 

--- a/features/validation/unevaluated.feature
+++ b/features/validation/unevaluated.feature
@@ -1,0 +1,104 @@
+Feature: Unevaluated properties and items (JSON Schema 2020-12)
+
+  Scenario: unevaluatedProperties false with properties
+    Given a YAML schema:
+      ```
+      type: object
+      properties:
+        a:
+          type: string
+      unevaluatedProperties: false
+      ```
+    Then it should accept:
+      ```
+      a: hello
+      ```
+    But it should NOT accept:
+      ```
+      a: hello
+      b: extra
+      ```
+
+  Scenario: allOf merges evaluated names for unevaluatedProperties
+    Given a YAML schema:
+      ```
+      allOf:
+        - properties:
+            a:
+              type: string
+        - unevaluatedProperties: false
+      ```
+    Then it should accept:
+      ```
+      a: x
+      ```
+    But it should NOT accept:
+      ```
+      a: x
+      b: y
+      ```
+
+  Scenario: unevaluatedItems after prefixItems only
+    Given a YAML schema:
+      ```
+      type: array
+      prefixItems:
+        - type: integer
+      unevaluatedItems:
+        type: string
+      ```
+    Then it should accept:
+      ```
+      - 1
+      - foo
+      - bar
+      ```
+    But it should NOT accept:
+      ```
+      - 1
+      - 2
+      ```
+
+  Scenario: unevaluatedItems applies to all indices when no items or prefixItems
+    Given a YAML schema:
+      ```
+      type: array
+      unevaluatedItems:
+        type: integer
+      ```
+    Then it should accept:
+      ```
+      - 1
+      - 2
+      ```
+    But it should NOT accept:
+      ```
+      - 1
+      - hi
+      ```
+
+  Scenario: anyOf successful branches merge annotations for unevaluatedProperties
+    Given a YAML schema:
+      ```
+      anyOf:
+        - properties:
+            a:
+              type: string
+        - properties:
+            b:
+              type: string
+      unevaluatedProperties: false
+      ```
+    Then it should accept:
+      ```
+      a: ok
+      ```
+    And it should accept:
+      ```
+      b: ok
+      ```
+    But it should NOT accept:
+      ```
+      a: ok
+      c: extra
+      ```

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -267,6 +267,28 @@ pub fn load_array_items_marked<'input>(value: &MarkedYaml<'input>) -> Result<Boo
     }
 }
 
+/// Load a boolean or schema mapping (e.g. `additionalProperties`, `unevaluatedProperties`, `unevaluatedItems`).
+pub fn load_boolean_or_schema_marked(value: &MarkedYaml<'_>) -> Result<BooleanOrSchema> {
+    match &value.data {
+        YamlData::Value(scalar) => match scalar {
+            Scalar::Boolean(b) => Ok(BooleanOrSchema::Boolean(*b)),
+            _ => Err(generic_error!(
+                "{} Expected a boolean scalar, but got: {:?}",
+                format_marker(&value.span.start),
+                scalar
+            )),
+        },
+        YamlData::Mapping(_) => {
+            let schema: YamlSchema = value.try_into()?;
+            Ok(BooleanOrSchema::schema(schema))
+        }
+        _ => Err(unsupported_type!(
+            "Expected boolean or mapping, but got: {:?}",
+            value
+        )),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use regex::Regex;

--- a/src/schemas/any_of.rs
+++ b/src/schemas/any_of.rs
@@ -70,12 +70,10 @@ pub fn validate_any_of(
     marked_yaml: &saphyr::MarkedYaml,
 ) -> Result<bool> {
     debug!("[AnyOf] &context: {context:p}");
+    let mut any_ok = false;
     for schema in schemas {
         debug!("[AnyOf] Validating value: {marked_yaml:?} against schema: {schema}");
-        // Since we're only looking for the first match, we can stop as soon as we find one
-        // That also means that when evaluating sub schemas, we can fail fast to short circuit
-        // the rest of the validation
-        let sub_context = context.get_sub_context();
+        let sub_context = context.get_sub_context_fresh_eval();
         debug!("[AnyOf]     context: {context:?}");
         debug!("[AnyOf] sub_context: {sub_context:?}");
         match schema.validate(&sub_context, marked_yaml) {
@@ -84,14 +82,24 @@ pub fn validate_any_of(
                     continue;
                 }
                 debug!("[AnyOf] Schema {schema:?} matched");
-                return Ok(true);
+                any_ok = true;
+                if let (Some(p), Some(b)) =
+                    (&context.object_evaluated, &sub_context.object_evaluated)
+                {
+                    p.extend(&b.snapshot());
+                }
+                if let (Some(pcell), Some(bcell)) =
+                    (&context.array_unevaluated, &sub_context.array_unevaluated)
+                {
+                    let snap = bcell.borrow().clone();
+                    pcell.borrow_mut().merge_from(&snap);
+                }
             }
             Err(e) => return Err(e),
         }
     }
-    debug!("[AnyOf] None of the schemas matched");
-    // If we get here, then none of the schemas matched
-    Ok(false)
+    debug!("[AnyOf] any_ok: {any_ok}");
+    Ok(any_ok)
 }
 
 #[cfg(test)]

--- a/src/schemas/array.rs
+++ b/src/schemas/array.rs
@@ -121,6 +121,9 @@ impl<'r> TryFrom<&AnnotatedMapping<'r, MarkedYaml<'r>>> for ArraySchema {
                             ));
                         }
                     }
+                    "unevaluatedItems" => {
+                        // Loaded on `Subschema`; ignore here when parsing `type: array` mapping.
+                    }
                     _ => debug!("Unsupported key for ArraySchema: {}", s),
                 }
             } else {
@@ -142,6 +145,8 @@ impl Validator for ArraySchema {
         debug!("[ArraySchema] Validating value: {}", format_yaml_data(data));
 
         if let saphyr::YamlData::Sequence(array) = data {
+            let err_after_meta = context.errors.borrow().len();
+
             // validate contains with minContains / maxContains
             if let Some(min_items) = self.min_items
                 && array.len() < min_items
@@ -272,6 +277,10 @@ impl Validator for ArraySchema {
                 }
             }
 
+            if context.errors.borrow().len() == err_after_meta {
+                Self::record_unevaluated_array_annotations(self, context, array);
+            }
+
             Ok(())
         } else {
             debug!("[ArraySchema] context.fail_fast: {}", context.fail_fast);
@@ -284,6 +293,82 @@ impl Validator for ArraySchema {
             );
             fail_fast!(context);
             Ok(())
+        }
+    }
+}
+
+impl ArraySchema {
+    /// Update [`Context::array_unevaluated`] from this schema's `prefixItems` / `items` / `contains` (2020-12).
+    fn record_unevaluated_array_annotations(
+        schema: &ArraySchema,
+        context: &Context,
+        array: &[MarkedYaml],
+    ) {
+        let Some(cell) = context.array_unevaluated.as_ref() else {
+            return;
+        };
+        let mut ann = cell.borrow_mut();
+
+        if let Some(sub_schema) = &schema.contains {
+            ann.saw_relevant = true;
+            if array.is_empty() {
+                // Annotation still present for empty instance (Core §10.3.1.3).
+            } else {
+                let mut matching = HashSet::new();
+                for (i, item) in array.iter().enumerate() {
+                    let sub_context = Context {
+                        root_schema: context.root_schema,
+                        fail_fast: true,
+                        ..Default::default()
+                    };
+                    if sub_schema.validate(&sub_context, item).is_ok() && !sub_context.has_errors()
+                    {
+                        matching.insert(i);
+                    }
+                }
+                if matching.len() == array.len() {
+                    ann.contains_all = true;
+                } else {
+                    ann.contains_indices.extend(matching);
+                }
+            }
+        }
+
+        if let Some(prefix_items) = &schema.prefix_items
+            && !prefix_items.is_empty()
+            && !array.is_empty()
+        {
+            let n = array.len().min(prefix_items.len());
+            if n > 0 {
+                ann.saw_relevant = true;
+                let largest = n - 1;
+                ann.prefix_largest = Some(match ann.prefix_largest {
+                    Some(p) => p.max(largest),
+                    None => largest,
+                });
+            }
+        }
+
+        let prefix_len = schema.prefix_items.as_ref().map(|p| p.len()).unwrap_or(0);
+        let tail_non_empty = array.len() > prefix_len;
+        let items_covers_all = prefix_len == 0 && !array.is_empty();
+
+        if let Some(items) = &schema.items {
+            match items {
+                BooleanOrSchema::Boolean(true) => {
+                    if tail_non_empty || items_covers_all {
+                        ann.saw_relevant = true;
+                        ann.full_coverage = true;
+                    }
+                }
+                BooleanOrSchema::Schema(_) => {
+                    if tail_non_empty || items_covers_all {
+                        ann.saw_relevant = true;
+                        ann.full_coverage = true;
+                    }
+                }
+                BooleanOrSchema::Boolean(false) => {}
+            }
         }
     }
 }

--- a/src/schemas/if_then_else.rs
+++ b/src/schemas/if_then_else.rs
@@ -82,7 +82,7 @@ impl Validator for IfThenElseSchema {
             "if/then/else: validating instance against `if` schema: {}",
             self.if_schema
         );
-        let if_context = context.get_sub_context();
+        let if_context = context.get_sub_context_fresh_eval();
         let if_result = self.if_schema.validate(&if_context, value);
 
         let if_passed = match if_result {
@@ -91,6 +91,15 @@ impl Validator for IfThenElseSchema {
         };
 
         if if_passed {
+            if let (Some(p), Some(f)) = (&context.object_evaluated, &if_context.object_evaluated) {
+                p.extend(&f.snapshot());
+            }
+            if let (Some(pcell), Some(fcell)) =
+                (&context.array_unevaluated, &if_context.array_unevaluated)
+            {
+                let snap = fcell.borrow().clone();
+                pcell.borrow_mut().merge_from(&snap);
+            }
             if let Some(then_s) = &self.then_schema {
                 then_s.validate(context, value)?;
             }

--- a/src/schemas/object.rs
+++ b/src/schemas/object.rs
@@ -154,6 +154,9 @@ impl<'r> TryFrom<&AnnotatedMapping<'r, MarkedYaml<'r>>> for ObjectSchema {
                         object_schema.dependent_schemas =
                             Some(load_dependent_schemas_marked(value)?);
                     }
+                    "unevaluatedProperties" => {
+                        // Loaded on `Subschema`; ignore here when parsing `type: object` mapping.
+                    }
                     // Maybe this should be handled by the base schema?
                     "type" => {
                         if let YamlData::Value(Scalar::String(s)) = &value.data {

--- a/src/schemas/one_of.rs
+++ b/src/schemas/one_of.rs
@@ -12,6 +12,7 @@ use crate::YamlSchema;
 use crate::loader;
 use crate::utils::format_vec;
 use crate::utils::format_yaml_data;
+use crate::validation::ArrayUnevaluatedAnnotations;
 
 /// The `oneOf` schema is a schema that matches if one, and only one of the schemas in the `oneOf` array match.
 /// The schemas are tried in order, and the first match is used. If no match is found, an error is added
@@ -74,13 +75,16 @@ pub fn validate_one_of(
     schemas: &[YamlSchema],
     value: &saphyr::MarkedYaml,
 ) -> Result<bool> {
-    let mut one_of_is_valid = false;
+    let mut match_count = 0usize;
+    let mut winning_obj = None;
+    let mut winning_arr: Option<ArrayUnevaluatedAnnotations> = None;
+
     for schema in schemas {
         debug!(
             "[OneOf] Validating value: {:?} against schema: {}",
             &value.data, schema
         );
-        let sub_context = context.get_sub_context();
+        let sub_context = context.get_sub_context_fresh_eval();
         let sub_result = schema.validate(&sub_context, value);
         match sub_result {
             Ok(()) | Err(Error::FailFast) => {
@@ -92,19 +96,37 @@ pub fn validate_one_of(
                     continue;
                 }
 
-                if one_of_is_valid {
-                    error!("[OneOf] Value matched multiple schemas in `oneOf`!");
-                    context.add_error(value, "Value matched multiple schemas in `oneOf`!");
-                    fail_fast!(context);
-                } else {
-                    one_of_is_valid = true;
+                match_count += 1;
+                if match_count == 1 {
+                    winning_obj = sub_context.object_evaluated.as_ref().map(|o| o.snapshot());
+                    winning_arr = sub_context
+                        .array_unevaluated
+                        .as_ref()
+                        .map(|a| a.borrow().clone());
                 }
             }
             Err(e) => return Err(e),
         }
     }
-    debug!("OneOf: one_of_is_valid: {one_of_is_valid}");
-    Ok(one_of_is_valid)
+
+    if match_count > 1 {
+        error!("[OneOf] Value matched multiple schemas in `oneOf`!");
+        context.add_error(value, "Value matched multiple schemas in `oneOf`!");
+        fail_fast!(context);
+        return Ok(false);
+    }
+
+    if match_count == 1 {
+        if let (Some(p), Some(s)) = (&context.object_evaluated, winning_obj) {
+            p.extend(&s);
+        }
+        if let (Some(pcell), Some(snap)) = (&context.array_unevaluated, winning_arr) {
+            pcell.borrow_mut().merge_from(&snap);
+        }
+    }
+
+    debug!("OneOf: match_count: {match_count}");
+    Ok(match_count == 1)
 }
 
 #[cfg(test)]

--- a/src/schemas/yaml_schema.rs
+++ b/src/schemas/yaml_schema.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fmt::Display;
 use std::rc::Rc;
 
@@ -14,6 +15,7 @@ use crate::RefUri;
 use crate::Reference;
 use crate::Result;
 use crate::Validator;
+use crate::loader::load_boolean_or_schema_marked;
 use crate::loader::load_external_schema;
 use crate::loader::marked_yaml_to_string;
 use crate::schemas::AllOfSchema;
@@ -34,6 +36,8 @@ use crate::utils::format_marker;
 use crate::utils::format_scalar;
 use crate::utils::format_vec;
 use crate::utils::format_yaml_data;
+use crate::utils::scalar_to_string;
+use crate::validation::ArrayUnevaluatedAnnotations;
 
 /// YamlSchema is the base of the validation model
 #[derive(Debug, PartialEq)]
@@ -338,6 +342,10 @@ pub struct Subschema {
     pub number_schema: Option<NumberSchema>,
     pub object_schema: Option<ObjectSchema>,
     pub string_schema: Option<StringSchema>,
+    /// `unevaluatedProperties` (JSON Schema 2020-12 unevaluated vocabulary).
+    pub unevaluated_properties: Option<BooleanOrSchema>,
+    /// `unevaluatedItems`.
+    pub unevaluated_items: Option<BooleanOrSchema>,
 }
 
 impl Subschema {
@@ -601,6 +609,15 @@ impl<'r> TryFrom<&AnnotatedMapping<'r, MarkedYaml<'r>>> for Subschema {
             string_schema = StringSchema::try_from(mapping).map(Some)?;
         }
 
+        let unevaluated_properties = mapping
+            .get(&MarkedYaml::value_from_str("unevaluatedProperties"))
+            .map(load_boolean_or_schema_marked)
+            .transpose()?;
+        let unevaluated_items = mapping
+            .get(&MarkedYaml::value_from_str("unevaluatedItems"))
+            .map(load_boolean_or_schema_marked)
+            .transpose()?;
+
         debug!("[Subschema#try_from] array_schema: {array_schema:?}");
         debug!("[Subschema#try_from] integer_schema: {integer_schema:?}");
         debug!("[Subschema#try_from] number_schema: {number_schema:?}");
@@ -624,6 +641,8 @@ impl<'r> TryFrom<&AnnotatedMapping<'r, MarkedYaml<'r>>> for Subschema {
             number_schema,
             object_schema,
             string_schema,
+            unevaluated_properties,
+            unevaluated_items,
             anchor: None,
         })
     }
@@ -789,34 +808,38 @@ impl Validator for Subschema {
             }
         }
 
+        // `unevaluated*` on the same mapping as `$ref` are not applied when `$ref` is present
+        // (validation returns above). See gap #1 / `$ref` sibling behavior.
+        let ctx = Self::validation_context_for_instance(context, value);
+
         if let Some(any_of) = &self.any_of {
             debug!("[Subschema] Validating anyOf schema: {any_of:?}");
-            any_of.validate(context, value)?;
+            any_of.validate(&ctx, value)?;
         }
 
         if let Some(all_of) = &self.all_of {
             debug!("[Subschema] Validating allOf schema: {all_of:?}");
-            all_of.validate(context, value)?;
+            all_of.validate(&ctx, value)?;
         }
 
         if let Some(one_of) = &self.one_of {
             debug!("[Subschema] Validating oneOf schema: {one_of:?}");
-            one_of.validate(context, value)?;
+            one_of.validate(&ctx, value)?;
         }
 
         if let Some(not) = &self.not {
             debug!("[Subschema] Validating not schema: {not:?}");
-            not.validate(context, value)?;
+            not.validate(&ctx, value)?;
         }
 
         if let Some(if_then_else) = &self.if_then_else {
             debug!("[Subschema] Validating if/then/else: {if_then_else:?}");
-            if_then_else.validate(context, value)?;
+            if_then_else.validate(&ctx, value)?;
         }
 
         match &self.r#type {
             SchemaType::None => (),
-            SchemaType::Single(s) => self.validate_by_type(context, s.as_ref(), value)?,
+            SchemaType::Single(s) => self.validate_by_type(&ctx, s.as_ref(), value)?,
             SchemaType::Multiple(values) => {
                 debug!(
                     "[Subschema] Validating multiple types: {}",
@@ -824,7 +847,7 @@ impl Validator for Subschema {
                 );
                 let mut any_matched = false;
                 for s in values {
-                    let sub_context = context.get_sub_context();
+                    let sub_context = ctx.get_sub_context();
                     self.validate_by_type(&sub_context, s.as_ref(), value)?;
                     if !sub_context.has_errors() {
                         any_matched = true;
@@ -832,7 +855,7 @@ impl Validator for Subschema {
                     }
                 }
                 if !any_matched {
-                    context.add_error(
+                    ctx.add_error(
                         value,
                         format!("None of type: [{}] matched", values.join(", ")),
                     );
@@ -843,7 +866,7 @@ impl Validator for Subschema {
         if let Some(r#const) = &self.r#const
             && !r#const.accepts(value)
         {
-            context.add_error(
+            ctx.add_error(
                 value,
                 format!(
                     "Expected const: {:#?}, but got: {}",
@@ -855,14 +878,119 @@ impl Validator for Subschema {
 
         if let Some(r#enum) = &self.r#enum {
             debug!("[Subschema] Validating enum schema: {}", r#enum);
-            r#enum.validate(context, value)?;
+            r#enum.validate(&ctx, value)?;
         }
+
+        self.apply_unevaluated(&ctx, value)?;
 
         Ok(())
     }
 }
 
 impl Subschema {
+    fn validation_context_for_instance<'r>(base: &Context<'r>, value: &MarkedYaml) -> Context<'r> {
+        match &value.data {
+            YamlData::Mapping(_) => {
+                let oe = base.object_evaluated.clone().unwrap_or_default();
+                base.with_object_evaluated(Some(oe))
+            }
+            YamlData::Sequence(_) => {
+                let arr = base
+                    .array_unevaluated
+                    .clone()
+                    .unwrap_or_else(ArrayUnevaluatedAnnotations::new_shared);
+                base.with_array_unevaluated(Some(arr))
+            }
+            _ => base
+                .with_object_evaluated(base.object_evaluated.clone())
+                .with_array_unevaluated(base.array_unevaluated.clone()),
+        }
+    }
+
+    fn apply_unevaluated(&self, ctx: &Context, value: &MarkedYaml) -> Result<()> {
+        if let YamlData::Mapping(mapping) = &value.data
+            && let Some(u) = &self.unevaluated_properties
+        {
+            let evaluated: HashSet<String> = ctx
+                .object_evaluated
+                .as_ref()
+                .map(|o| o.snapshot())
+                .unwrap_or_default();
+            for (k, v) in mapping.iter() {
+                let key_string = match &k.data {
+                    YamlData::Value(scalar) => scalar_to_string(scalar),
+                    _ => {
+                        return Err(expected_scalar!(
+                            "[{}] Expected a scalar object key, got: {:?}",
+                            format_marker(&k.span.start),
+                            k.data
+                        ));
+                    }
+                };
+                if key_string == "$schema" {
+                    continue;
+                }
+                if evaluated.contains(&key_string) {
+                    continue;
+                }
+                let prop_ctx = ctx.append_path(&key_string);
+                match u {
+                    BooleanOrSchema::Boolean(false) => {
+                        ctx.add_error(
+                            v,
+                            format!("Unevaluated property '{key_string}' is not allowed!"),
+                        );
+                    }
+                    BooleanOrSchema::Boolean(true) => {}
+                    BooleanOrSchema::Schema(s) => {
+                        s.validate(&prop_ctx, v)?;
+                    }
+                }
+            }
+        }
+
+        if let YamlData::Sequence(seq) = &value.data
+            && let Some(u) = &self.unevaluated_items
+        {
+            let ann = ctx
+                .array_unevaluated
+                .as_ref()
+                .map(|c| c.borrow().clone())
+                .unwrap_or_default();
+            if ann.full_coverage {
+                return Ok(());
+            }
+            let indices = ann.indices_requiring_unevaluated(seq.len());
+            let err_before = ctx.errors.borrow().len();
+            for i in indices.iter().copied() {
+                let item = &seq[i];
+                let item_ctx = ctx.append_path(i.to_string());
+                match u {
+                    BooleanOrSchema::Boolean(false) => {
+                        ctx.add_error(
+                            item,
+                            format!("Unevaluated array item at index {i} is not allowed!"),
+                        );
+                    }
+                    BooleanOrSchema::Boolean(true) => {}
+                    BooleanOrSchema::Schema(s) => {
+                        s.validate(&item_ctx, item)?;
+                    }
+                }
+            }
+            if ctx.errors.borrow().len() == err_before
+                && !indices.is_empty()
+                && let Some(cell) = &ctx.array_unevaluated
+            {
+                let mut a = cell.borrow_mut();
+                a.saw_relevant = true;
+                a.full_coverage = true;
+            }
+        }
+
+        Ok(())
+    }
+
     fn validate_by_type(
         &self,
         context: &Context,
@@ -1214,5 +1342,23 @@ mod tests {
         let result = schema.validate(&context, value);
         assert!(result.is_ok());
         assert!(!context.has_errors());
+    }
+
+    #[test]
+    fn unevaluated_properties_all_of_extra_key_rejected() {
+        let root = loader::load_from_str(
+            r#"
+            allOf:
+              - properties:
+                  a:
+                    type: string
+              - unevaluatedProperties: false
+            "#,
+        )
+        .unwrap();
+        let ok = engine::Engine::evaluate(&root, "a: ok", false).unwrap();
+        assert!(!ok.has_errors());
+        let bad = engine::Engine::evaluate(&root, "a: ok\nb: no", false).unwrap();
+        assert!(bad.has_errors());
     }
 }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -4,11 +4,14 @@ use saphyr::Marker;
 
 use crate::Result;
 
+pub(crate) mod annotations;
 mod context;
 pub(crate) mod formats;
 mod objects;
 mod strings;
 
+pub use annotations::ArrayUnevaluatedAnnotations;
+pub use annotations::ObjectEvaluatedNames;
 pub use context::Context;
 
 /// A trait for validating a sahpyr::Yaml value against a schema

--- a/src/validation/annotations.rs
+++ b/src/validation/annotations.rs
@@ -1,0 +1,93 @@
+//! Annotation state for JSON Schema 2020-12 `unevaluatedProperties` / `unevaluatedItems`.
+
+use std::cell::RefCell;
+use std::collections::HashSet;
+use std::rc::Rc;
+
+/// Successfully evaluated object property names at one instance (for `unevaluatedProperties`).
+#[derive(Debug, Clone, Default)]
+pub struct ObjectEvaluatedNames {
+    pub names: Rc<RefCell<HashSet<String>>>,
+}
+
+impl ObjectEvaluatedNames {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&self, name: impl Into<String>) {
+        self.names.borrow_mut().insert(name.into());
+    }
+
+    pub fn extend(&self, other: &HashSet<String>) {
+        self.names.borrow_mut().extend(other.iter().cloned());
+    }
+
+    pub fn snapshot(&self) -> HashSet<String> {
+        self.names.borrow().clone()
+    }
+}
+
+/// Tracks keywords that feed `unevaluatedItems` at one array instance (JSON Schema 2020-12 §11.2).
+#[derive(Debug, Clone, Default)]
+pub struct ArrayUnevaluatedAnnotations {
+    /// Any annotation from prefixItems, items, contains, unevaluatedItems, or merged in-place applicators.
+    pub saw_relevant: bool,
+    /// Boolean true from `items` or nested `unevaluatedItems` → ignore unevaluatedItems.
+    pub full_coverage: bool,
+    /// Largest index prefixItems applied a subschema to (`None` if prefixItems absent or empty).
+    pub prefix_largest: Option<usize>,
+    /// Indices where contains matched successfully.
+    pub contains_indices: HashSet<usize>,
+    /// Contains produced boolean true (every index).
+    pub contains_all: bool,
+}
+
+impl ArrayUnevaluatedAnnotations {
+    pub fn new_shared() -> Rc<RefCell<Self>> {
+        Rc::new(RefCell::new(Self::default()))
+    }
+
+    /// Indices that must still be validated by `unevaluatedItems` (JSON Schema 2020-12 §11.2).
+    pub fn indices_requiring_unevaluated(&self, len: usize) -> Vec<usize> {
+        if self.full_coverage {
+            return Vec::new();
+        }
+        if !self.saw_relevant {
+            return (0..len).collect();
+        }
+        let start = self
+            .prefix_largest
+            .map(|p| p.saturating_add(1))
+            .unwrap_or(0);
+        let mut out = Vec::new();
+        for i in start..len {
+            if self.contains_all || self.contains_indices.contains(&i) {
+                continue;
+            }
+            out.push(i);
+        }
+        out
+    }
+
+    /// Merge another branch's annotations (e.g. successful `anyOf` sibling). Union semantics.
+    pub fn merge_from(&mut self, other: &ArrayUnevaluatedAnnotations) {
+        if other.saw_relevant {
+            self.saw_relevant = true;
+        }
+        if other.full_coverage {
+            self.full_coverage = true;
+        }
+        self.prefix_largest = match (self.prefix_largest, other.prefix_largest) {
+            (Some(a), Some(b)) => Some(a.max(b)),
+            (Some(a), None) => Some(a),
+            (None, Some(b)) => Some(b),
+            (None, None) => None,
+        };
+        if other.contains_all {
+            self.contains_all = true;
+        }
+        self.contains_indices
+            .extend(other.contains_indices.iter().copied());
+    }
+}

--- a/src/validation/context.rs
+++ b/src/validation/context.rs
@@ -5,6 +5,8 @@ use std::rc::Rc;
 
 use crate::RootSchema;
 use crate::YamlSchema;
+use crate::validation::ArrayUnevaluatedAnnotations;
+use crate::validation::ObjectEvaluatedNames;
 use crate::validation::ValidationError;
 
 /// The validation context
@@ -25,6 +27,10 @@ pub struct Context<'r> {
     pub resolving_refs: Rc<RefCell<HashSet<(String, usize)>>>,
     /// Cache of externally loaded schemas by absolute URI (without fragment) or `$id` when valid.
     pub schemas: Rc<RefCell<HashMap<String, Rc<RootSchema>>>>,
+    /// Property names successfully evaluated for JSON Schema `unevaluatedProperties` (same instance).
+    pub object_evaluated: Option<ObjectEvaluatedNames>,
+    /// Array annotation state for JSON Schema `unevaluatedItems` (same instance).
+    pub array_unevaluated: Option<Rc<RefCell<ArrayUnevaluatedAnnotations>>>,
 }
 
 impl Default for Context<'_> {
@@ -39,6 +45,8 @@ impl Default for Context<'_> {
             fail_fast: false,
             resolving_refs: Rc::new(RefCell::new(HashSet::new())),
             schemas: Rc::new(RefCell::new(HashMap::new())),
+            object_evaluated: None,
+            array_unevaluated: None,
         }
     }
 }
@@ -72,6 +80,25 @@ impl<'r> Context<'r> {
             fail_fast: self.fail_fast,
             resolving_refs: self.resolving_refs.clone(),
             schemas: self.schemas.clone(),
+            object_evaluated: self.object_evaluated.clone(),
+            array_unevaluated: self.array_unevaluated.clone(),
+        }
+    }
+
+    /// Like [`get_sub_context`], but with fresh unevaluated annotation carriers (for `anyOf` / `oneOf` branches).
+    pub fn get_sub_context_fresh_eval(&self) -> Context<'r> {
+        Context {
+            root_schema: self.root_schema,
+            current_schema: self.current_schema,
+            current_path: self.current_path.clone(),
+            stream_started: self.stream_started,
+            stream_ended: self.stream_ended,
+            errors: Rc::new(RefCell::new(Vec::new())),
+            fail_fast: self.fail_fast,
+            resolving_refs: self.resolving_refs.clone(),
+            schemas: self.schemas.clone(),
+            object_evaluated: Some(ObjectEvaluatedNames::new()),
+            array_unevaluated: Some(ArrayUnevaluatedAnnotations::new_shared()),
         }
     }
 
@@ -139,6 +166,53 @@ impl<'r> Context<'r> {
             stream_started: self.stream_started,
             resolving_refs: self.resolving_refs.clone(),
             schemas: self.schemas.clone(),
+            object_evaluated: None,
+            array_unevaluated: None,
+        }
+    }
+
+    /// Record a successfully evaluated object property name (`properties` / `patternProperties` / `additionalProperties`).
+    pub fn record_evaluated_property(&self, name: &str) {
+        if let Some(oe) = &self.object_evaluated {
+            oe.insert(name.to_string());
+        }
+    }
+
+    pub fn with_object_evaluated(
+        &self,
+        object_evaluated: Option<ObjectEvaluatedNames>,
+    ) -> Context<'r> {
+        Context {
+            root_schema: self.root_schema,
+            current_schema: self.current_schema,
+            current_path: self.current_path.clone(),
+            stream_started: self.stream_started,
+            stream_ended: self.stream_ended,
+            errors: self.errors.clone(),
+            fail_fast: self.fail_fast,
+            resolving_refs: self.resolving_refs.clone(),
+            schemas: self.schemas.clone(),
+            object_evaluated,
+            array_unevaluated: self.array_unevaluated.clone(),
+        }
+    }
+
+    pub fn with_array_unevaluated(
+        &self,
+        array_unevaluated: Option<Rc<RefCell<ArrayUnevaluatedAnnotations>>>,
+    ) -> Context<'r> {
+        Context {
+            root_schema: self.root_schema,
+            current_schema: self.current_schema,
+            current_path: self.current_path.clone(),
+            stream_started: self.stream_started,
+            stream_ended: self.stream_ended,
+            errors: self.errors.clone(),
+            fail_fast: self.fail_fast,
+            resolving_refs: self.resolving_refs.clone(),
+            schemas: self.schemas.clone(),
+            object_evaluated: self.object_evaluated.clone(),
+            array_unevaluated,
         }
     }
 

--- a/src/validation/objects.rs
+++ b/src/validation/objects.rs
@@ -41,9 +41,15 @@ pub fn try_validate_value_against_properties(
     let sub_context = context.append_path(key);
     if let Some(schema) = properties.get(key) {
         debug!("Validating property '{key}' with schema: {schema}");
+        let err_before = context.errors.borrow().len();
         let result = schema.validate(&sub_context, value);
         return match result {
-            Ok(_) => Ok(true),
+            Ok(()) => {
+                if context.errors.borrow().len() == err_before {
+                    context.record_evaluated_property(key);
+                }
+                Ok(true)
+            }
             Err(e) => Err(e),
         };
     }
@@ -126,12 +132,17 @@ impl ObjectSchema {
             let mut matched_pattern_property = false;
             if let Some(pattern_properties) = &self.pattern_properties {
                 let pattern_context = context.append_path(&key_string);
+                let err_before_patterns = context.errors.borrow().len();
                 for pp in pattern_properties {
                     log::debug!("pattern: {}", pp.regex.as_str());
                     if pp.regex.is_match(key_string.as_ref()) {
                         matched_pattern_property = true;
                         pp.schema.validate(&pattern_context, value)?;
                     }
+                }
+                if matched_pattern_property && context.errors.borrow().len() == err_before_patterns
+                {
+                    context.record_evaluated_property(&key_string);
                 }
             }
 
@@ -141,12 +152,16 @@ impl ObjectSchema {
                 && !matched_pattern_property
                 && let Some(additional_properties) = &self.additional_properties
             {
+                let err_before_add = context.errors.borrow().len();
                 try_validate_value_against_additional_properties(
                     context,
                     &key_string,
                     value,
                     additional_properties,
                 )?;
+                if context.errors.borrow().len() == err_before_add {
+                    context.record_evaluated_property(&key_string);
+                }
             }
             // Finally, we check if it matches property_names
             if let Some(property_names) = &self.property_names {

--- a/yaml-schema.yaml
+++ b/yaml-schema.yaml
@@ -159,4 +159,19 @@ properties:
     patternProperties:
       "^[a-zA-Z0-9_-]+$":
         $ref: "#/$defs/schema"
+  unevaluatedProperties:
+    description: >-
+      JSON Schema 2020-12 unevaluated vocabulary. Applies to object properties not already
+      evaluated by properties, patternProperties, additionalProperties, or in-place applicators
+      (e.g. allOf).
+    oneOf:
+      - type: boolean
+      - $ref: "#/$defs/schema"
+  unevaluatedItems:
+    description: >-
+      JSON Schema 2020-12 unevaluated vocabulary. Applies to array elements not already
+      evaluated by prefixItems, items, contains, or in-place applicators.
+    oneOf:
+      - type: boolean
+      - $ref: "#/$defs/schema"
 additionalProperties: false


### PR DESCRIPTION
## Summary

Implements JSON Schema 2020-12 style **unevaluatedProperties** and **unevaluatedItems**: extra object properties and array elements must be covered by evaluated schemas, with boolean `false` rejecting extras or a nested schema constraining them.

## Key changes

- **Annotations & context**: Track evaluated property names and array `unevaluated` state through validation; merge across composition where the spec requires it (e.g. successful **anyOf** branches).
- **Composition**: Adjust **anyOf** / **oneOf** / **allOf** / **if/then/else** paths so sub-context evaluation state can be merged for unevaluated keyword behavior.
- **Arrays & objects**: Wire **unevaluatedItems** (with **prefixItems**) and **unevaluatedProperties** into array/object validation.
- **Loader**: `load_boolean_or_schema_marked` for boolean-or-schema keywords.
- **Meta-schema**: Document `unevaluatedProperties` / `unevaluatedItems` in `yaml-schema.yaml`.
- **Tests**: New Cucumber feature `features/validation/unevaluated.feature`; README link.

**Diff:** 14 files, +630 / −30 lines.

Made with [Cursor](https://cursor.com)