### PR TITLE
feat: JSON CLI output and humanized type-mismatch errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ ordered-float = "5.0.0"
 regex = "1.10.4"
 reqwest = { version = "0.12.22", features = ["blocking", "json", "native-tls"], default-features = false }
 saphyr = "0.0.6"
+serde_json = "~1.0"
 thiserror = "2.0"
 url = "2.5.7"
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,74 @@ ys -f schema.yaml invalid.yaml
 
 Should fail with exit code 1
 
+## JSON Output
+
+Pass `--json` to emit structured errors instead of plain text. Use it with the same options as usual.
+
+**Successful validation** (exit code `0`): stdout is empty.
+
+```
+ys --json -f schema.yaml valid.yaml
+```
+
+(no output on stdout)
+
+**Validation failures** (exit code `1`): stdout is a single JSON **array** of objects, one per error. Each object has:
+
+| Field   | Meaning |
+|--------|---------|
+| `index` | Byte offset into the source, or `null` if unknown |
+| `line`  | 1-based line number, or `null` if unknown |
+| `col`   | 0-based column index from the parser, or `null` if unknown |
+| `path`  | Dot-separated path from the document root (e.g. `foo`, `items.0`) |
+| `error` | Human-readable message |
+
+Using the same `schema.yaml` / `invalid.yaml` scenario as [above](#example-usage), with `foo` and `bar` violating their types:
+
+```sh
+ys --json -f schema.yaml invalid.yaml
+```
+
+stdout (pretty-printed; the tool emits compact JSON on one line):
+
+```json
+[
+  {
+    "col": 5,
+    "error": "Expected a string, but got: 42 (int)",
+    "index": 5,
+    "line": 1,
+    "path": "foo"
+  },
+  {
+    "col": 5,
+    "error": "Expected a number, but got: \"I'm a string\" (string)",
+    "index": 13,
+    "line": 2,
+    "path": "bar"
+  }
+]
+```
+
+**Other failures** (exit code `1`): schema load errors, missing arguments, YAML parse errors, and similar issues print a single JSON object on **stderr**: `{"error":"<message>"}`.
+
+If the schema file cannot be read:
+
+```sh
+ys --json -f /path/to/missing-schema.yaml valid.yaml
+```
+
+stderr:
+
+```json
+{"error":"Failed to read YAML schema file /path/to/missing-schema.yaml: No such file or directory (os error 2)"}
+```
+
+The exact `error` text depends on the failure (OS messages, parse errors, etc.).
+
+Validation errors are written to **stdout**; non-validation errors use **stderr**, so callers can distinguish validation results from tooling or I/O failures.
+
+
 ## Features
 
 **yaml-schema** uses [Cucumber](https://cucumber-rs.github.io/cucumber/main/) to specify and test features:

--- a/features/basics.feature
+++ b/features/basics.feature
@@ -145,4 +145,4 @@ Feature: Basic YAML schema
       foo: 42
       bar: "I'm a string"
       ```
-    And the error message should be "[1:6] .foo: Expected a string, but got: Value(Integer(42))"
+    And the error message should be "[1:6] .foo: Expected a string, but got: 42 (int)"

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -26,8 +26,8 @@ Feature: CLI usage
     Then it should exit with status code 1
     And stderr output should end with:
       ```
-      [1:6] .foo: Expected a string, but got: Value(Integer(42))
-      [2:6] .bar: Expected a number, but got: Value(String("I'm a string"))
+      [1:6] .foo: Expected a string, but got: 42 (int)
+      [2:6] .bar: Expected a number, but got: "I'm a string" (string)
       ```
 
   Scenario: Basic validation with an invalid file and JSON output

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -29,3 +29,11 @@ Feature: CLI usage
       [1:6] .foo: Expected a string, but got: Value(Integer(42))
       [2:6] .bar: Expected a number, but got: Value(String("I'm a string"))
       ```
+
+  Scenario: Basic validation with an invalid file and JSON output
+    When the following command is run:
+      ```
+      ys --json -f tests/fixtures/schema.yaml tests/fixtures/invalid.yaml
+      ```
+    Then it should exit with status code 1
+    And stdout should be a JSON array with two validation errors for paths foo and bar

--- a/src/bin/ys.rs
+++ b/src/bin/ys.rs
@@ -6,10 +6,12 @@ use clap::Parser;
 use clap::Subcommand;
 use eyre::Context;
 use eyre::Result;
+use serde_json::json;
 use url::Url;
 
 use yaml_schema::Engine;
 use yaml_schema::loader;
+use yaml_schema::validation::ValidationError;
 use yaml_schema::version;
 
 #[derive(Parser, Debug, Default)]
@@ -29,6 +31,10 @@ pub struct Opts {
     /// Specify this flag to exit (1) as soon as any error is encountered
     #[arg(long = "fail-fast", default_value = "false")]
     pub fail_fast: bool,
+    /// Emit errors as JSON: validation failures as a JSON array on stdout; other failures as
+    /// {"error":"..."} on stderr.
+    #[arg(long = "json")]
+    pub json: bool,
     /// The YAML file to validate
     pub file: Option<String>,
 }
@@ -37,6 +43,26 @@ pub struct Opts {
 pub enum Commands {
     #[command(about = "Display the ys version")]
     Version,
+}
+
+fn emit_json_error(message: &str) {
+    eprintln!("{}", json!({ "error": message }));
+}
+
+fn emit_validation_errors_json(errors: &[ValidationError]) {
+    let entries: Vec<serde_json::Value> = errors
+        .iter()
+        .map(|e| {
+            json!({
+                "index": e.marker.map(|m| m.index()),
+                "line": e.marker.map(|m| m.line()),
+                "col": e.marker.map(|m| m.col()),
+                "path": e.path,
+                "error": e.error,
+            })
+        })
+        .collect();
+    println!("{}", serde_json::Value::Array(entries));
 }
 
 /// The main entrypoint function of the ys executable
@@ -50,12 +76,17 @@ fn main() {
             }
         }
     } else {
+        let json = opts.json;
         match command_validate(opts) {
             Ok(return_code) => {
                 std::process::exit(return_code);
             }
             Err(e) => {
-                eprintln!("Validation failed: {e}");
+                if json {
+                    emit_json_error(&e.to_string());
+                } else {
+                    eprintln!("Validation failed: {e}");
+                }
                 std::process::exit(1);
             }
         }
@@ -73,6 +104,7 @@ fn schema_uri(path: &str) -> Result<String> {
 
 /// The `ys validate` command
 fn command_validate(opts: Opts) -> Result<i32> {
+    let json = opts.json;
     if opts.schemas.is_empty() {
         return Err(eyre::eyre!("No schema file(s) specified"));
     }
@@ -84,8 +116,12 @@ fn command_validate(opts: Opts) -> Result<i32> {
     let root_schema = match loader::load_file(root_path) {
         Ok(schema) => schema,
         Err(e) => {
-            eprintln!("Failed to read YAML schema file: {root_path}");
-            log::error!("{e}");
+            if json {
+                emit_json_error(&format!("Failed to read YAML schema file {root_path}: {e}"));
+            } else {
+                eprintln!("Failed to read YAML schema file: {root_path}");
+                log::error!("{e}");
+            }
             return Ok(1);
         }
     };
@@ -95,15 +131,23 @@ fn command_validate(opts: Opts) -> Result<i32> {
         let uri = match schema_uri(path) {
             Ok(u) => u,
             Err(e) => {
-                eprintln!("Failed to resolve schema path: {path}: {e}");
+                if json {
+                    emit_json_error(&format!("Failed to resolve schema path {path}: {e}"));
+                } else {
+                    eprintln!("Failed to resolve schema path: {path}: {e}");
+                }
                 return Ok(1);
             }
         };
         let schema = match loader::load_file(path) {
             Ok(s) => s,
             Err(e) => {
-                eprintln!("Failed to load schema file: {path}");
-                log::error!("{e}");
+                if json {
+                    emit_json_error(&format!("Failed to load schema file {path}: {e}"));
+                } else {
+                    eprintln!("Failed to load schema file: {path}");
+                    log::error!("{e}");
+                }
                 return Ok(1);
             }
         };
@@ -125,15 +169,24 @@ fn command_validate(opts: Opts) -> Result<i32> {
     match Engine::evaluate_with_schemas(&root_schema, &yaml_contents, opts.fail_fast, preloaded) {
         Ok(context) => {
             if context.has_errors() {
-                for error in context.errors.borrow().iter() {
-                    eprintln!("{error}");
+                let errors = context.errors.borrow();
+                if json {
+                    emit_validation_errors_json(errors.as_slice());
+                } else {
+                    for error in errors.iter() {
+                        eprintln!("{error}");
+                    }
                 }
                 return Ok(1);
             }
             Ok(0)
         }
         Err(e) => {
-            eprintln!("Validation failed: {e}");
+            if json {
+                emit_json_error(&format!("Validation failed: {e}"));
+            } else {
+                eprintln!("Validation failed: {e}");
+            }
             Ok(1)
         }
     }

--- a/src/schemas/integer.rs
+++ b/src/schemas/integer.rs
@@ -8,6 +8,7 @@ use crate::Number;
 use crate::Result;
 use crate::schemas::NumericBounds;
 use crate::utils::format_marker;
+use crate::utils::humanize_yaml_data;
 use crate::validation::Context;
 use crate::validation::Validator;
 
@@ -86,13 +87,25 @@ impl Validator for IntegerSchema {
                     self.bounds
                         .validate(context, value, Number::Integer(f as i64));
                 } else {
-                    context.add_error(value, format!("Expected an integer, but got: {data:?}"));
+                    context.add_error(
+                        value,
+                        format!("Expected an integer, but got: {}", humanize_yaml_data(data)),
+                    );
                 }
             } else {
-                context.add_error(value, format!("Expected a number, but got: {data:?}"));
+                context.add_error(
+                    value,
+                    format!("Expected a number, but got: {}", humanize_yaml_data(data)),
+                );
             }
         } else {
-            context.add_error(value, format!("Expected a scalar value, but got: {data:?}"));
+            context.add_error(
+                value,
+                format!(
+                    "Expected a scalar value, but got: {}",
+                    humanize_yaml_data(data)
+                ),
+            );
         }
         if !context.errors.borrow().is_empty() {
             fail_fast!(context)
@@ -121,7 +134,7 @@ mod tests {
         let first_error = errors.first().unwrap();
         assert_eq!(
             first_error.error,
-            "Expected a number, but got: Value(String(\"foo\"))"
+            r#"Expected a number, but got: "foo" (string)"#
         );
     }
 

--- a/src/schemas/number.rs
+++ b/src/schemas/number.rs
@@ -11,6 +11,7 @@ use crate::Result;
 use crate::schemas::NumericBounds;
 use crate::utils::format_hash_map;
 use crate::utils::format_marker;
+use crate::utils::humanize_yaml_data;
 use crate::validation::Context;
 use crate::validation::Validator;
 
@@ -32,10 +33,19 @@ impl Validator for NumberSchema {
                 self.bounds
                     .validate(context, value, Number::Float(ordered_float.into_inner()));
             } else {
-                context.add_error(value, format!("Expected a number, but got: {data:?}"));
+                context.add_error(
+                    value,
+                    format!("Expected a number, but got: {}", humanize_yaml_data(data)),
+                );
             }
         } else {
-            context.add_error(value, format!("Expected a scalar value, but got: {data:?}"));
+            context.add_error(
+                value,
+                format!(
+                    "Expected a scalar value, but got: {}",
+                    humanize_yaml_data(data)
+                ),
+            );
         }
         if context.has_errors() {
             fail_fast!(context)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -100,6 +100,60 @@ pub fn format_marker(marker: &saphyr::Marker) -> String {
     format!("[{}, {}]", marker.line(), marker.col())
 }
 
+/// Formats [`YamlData`] for human-readable type-mismatch messages in validation errors. Scalar
+/// kinds get a short type suffix; other shapes use [`Debug`] like the previous `{:?}` output.
+///
+/// # Examples
+///
+/// ```
+/// use std::borrow::Cow;
+/// use ordered_float::OrderedFloat;
+/// use saphyr::Scalar;
+/// use saphyr::YamlData;
+/// use yaml_schema::utils::humanize_yaml_data;
+///
+/// let data = YamlData::Value(Scalar::Integer(42));
+/// assert_eq!(humanize_yaml_data(&data), "42 (int)");
+///
+/// let data = YamlData::Value(Scalar::FloatingPoint(OrderedFloat::from(3.14)));
+/// assert_eq!(humanize_yaml_data(&data), "3.14 (float)");
+///
+/// let data = YamlData::Value(Scalar::Boolean(true));
+/// assert_eq!(humanize_yaml_data(&data), "true (bool)");
+///
+/// // Strings are JSON-encoded (quoted, with escapes) and suffixed with `(string)`:
+///
+/// let data = YamlData::Value(Scalar::String(Cow::Borrowed("hello")));
+/// assert_eq!(humanize_yaml_data(&data), r#""hello" (string)"#);
+///
+/// let data = YamlData::Value(Scalar::String(Cow::Borrowed("a\"b")));
+/// assert_eq!(humanize_yaml_data(&data), r#""a\"b" (string)"#);
+///
+/// // `Scalar::Null` and other shapes not given a custom format fall back to [`Debug`]:
+///
+/// let data = YamlData::Value(Scalar::Null);
+/// let s = humanize_yaml_data(&data);
+/// assert!(s.contains("Null"), "{s}");
+/// ```
+pub fn humanize_yaml_data<'input>(data: &YamlData<'input, MarkedYaml<'input>>) -> String {
+    match data {
+        YamlData::Value(Scalar::String(s)) => format!(
+            "{} (string)",
+            serde_json::to_string(s.as_ref()).unwrap_or_else(|_| format!("{:?}", s.as_ref()))
+        ),
+        YamlData::Value(Scalar::Integer(i)) => format!("{i} (int)"),
+        YamlData::Value(Scalar::FloatingPoint(f)) => {
+            let x = f.into_inner();
+            format!(
+                "{} (float)",
+                serde_json::to_string(&x).unwrap_or_else(|_| format!("{x}"))
+            )
+        }
+        YamlData::Value(Scalar::Boolean(b)) => format!("{b} (bool)"),
+        _ => format!("{data:?}"),
+    }
+}
+
 /// Formats a vector of values as a string, by joining them with commas
 pub fn format_vec<V>(vec: &[V]) -> String
 where
@@ -242,6 +296,63 @@ mod tests {
         assert_eq!(
             "{ \"foo\": \"bar\" }",
             format_linked_hash_map(&linked_hash_map)
+        );
+    }
+
+    #[test]
+    fn humanize_yaml_data_integer() {
+        let docs = MarkedYaml::load_from_str("42").unwrap();
+        assert_eq!(humanize_yaml_data(&docs.first().unwrap().data), "42 (int)");
+    }
+
+    #[test]
+    fn humanize_yaml_data_float() {
+        let docs = MarkedYaml::load_from_str("3.14").unwrap();
+        assert_eq!(
+            humanize_yaml_data(&docs.first().unwrap().data),
+            "3.14 (float)"
+        );
+    }
+
+    #[test]
+    fn humanize_yaml_data_boolean() {
+        let docs = MarkedYaml::load_from_str("true").unwrap();
+        assert_eq!(
+            humanize_yaml_data(&docs.first().unwrap().data),
+            "true (bool)"
+        );
+        let docs = MarkedYaml::load_from_str("false").unwrap();
+        assert_eq!(
+            humanize_yaml_data(&docs.first().unwrap().data),
+            "false (bool)"
+        );
+    }
+
+    #[test]
+    fn humanize_yaml_data_string_plain() {
+        let docs = MarkedYaml::load_from_str("hello").unwrap();
+        assert_eq!(
+            humanize_yaml_data(&docs.first().unwrap().data),
+            r#""hello" (string)"#
+        );
+    }
+
+    #[test]
+    fn humanize_yaml_data_string_with_quotes_escaped() {
+        let docs = MarkedYaml::load_from_str(r#""str\" ing""#).unwrap();
+        assert_eq!(
+            humanize_yaml_data(&docs.first().unwrap().data),
+            r#""str\" ing" (string)"#
+        );
+    }
+
+    #[test]
+    fn humanize_yaml_data_non_scalar_uses_debug() {
+        let docs = MarkedYaml::load_from_str("a: 1").unwrap();
+        let s = humanize_yaml_data(&docs.first().unwrap().data);
+        assert!(
+            s.starts_with("Mapping("),
+            "expected Debug fallback for mapping, got {s:?}"
         );
     }
 }

--- a/src/validation/objects.rs
+++ b/src/validation/objects.rs
@@ -325,10 +325,7 @@ mod tests {
         let errors = context.errors.borrow();
         let first_error = errors.first().unwrap();
         assert_eq!(first_error.path, "foo");
-        assert_eq!(
-            first_error.error,
-            "Expected a string, but got: Value(Integer(42))"
-        );
+        assert_eq!(first_error.error, "Expected a string, but got: 42 (int)");
     }
 
     #[test]

--- a/src/validation/strings.rs
+++ b/src/validation/strings.rs
@@ -6,6 +6,7 @@ use crate::Result;
 use crate::Validator;
 use crate::schemas::StringFormat;
 use crate::schemas::StringSchema;
+use crate::utils::humanize_yaml_data;
 use crate::validation::formats;
 
 impl Validator for StringSchema {
@@ -41,7 +42,10 @@ impl StringSchema {
                 s,
             );
         } else {
-            errors.push(format!("Expected a string, but got: {:?}", value.data));
+            errors.push(format!(
+                "Expected a string, but got: {}",
+                humanize_yaml_data(&value.data)
+            ));
         }
         errors
     }

--- a/tests/features.rs
+++ b/tests/features.rs
@@ -5,7 +5,9 @@ use cucumber::gherkin::Step;
 use cucumber::given;
 use cucumber::then;
 use cucumber::when;
-use log::{debug, error};
+use log::debug;
+use log::error;
+use serde_json::Value;
 use std::cell::RefCell;
 use std::rc::Rc;
 use yaml_schema::Engine;
@@ -158,6 +160,40 @@ async fn stderr_output_should_end_with(world: &mut FeaturesWorld, step: &Step) {
     assert!(
         actual.ends_with(expected),
         "Expected stderr to end with:\n{expected}\nBut got:\n{actual}"
+    );
+}
+
+#[then(regex = "stdout should be a JSON array with two validation errors for paths foo and bar")]
+async fn stdout_json_two_validation_errors(world: &mut FeaturesWorld) {
+    let output = world
+        .command_output
+        .as_ref()
+        .expect("No command has been run");
+    let v: Value = serde_json::from_str(output.stdout.trim()).expect("stdout should be JSON");
+    let arr = v.as_array().expect("stdout should be a JSON array");
+    assert_eq!(
+        arr.len(),
+        2,
+        "expected two validation errors, got {}",
+        arr.len()
+    );
+    for entry in arr {
+        let obj = entry.as_object().expect("each error should be an object");
+        for key in ["index", "line", "col", "path", "error"] {
+            assert!(obj.contains_key(key), "missing key {key} in {obj:?}");
+        }
+    }
+    let paths: Vec<&str> = arr
+        .iter()
+        .map(|e| {
+            e.get("path")
+                .and_then(|p| p.as_str())
+                .expect("path should be a string")
+        })
+        .collect();
+    assert!(
+        paths.contains(&"foo") && paths.contains(&"bar"),
+        "expected paths foo and bar, got {paths:?}"
     );
 }
 

--- a/tests/ys_cli_json.rs
+++ b/tests/ys_cli_json.rs
@@ -1,0 +1,53 @@
+use assert_cmd::Command;
+use serde_json::Value;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn validation_errors_stdout_is_json_array_with_multiple_entries() {
+    let dir = tempdir().expect("tempdir");
+    let schema_path = dir.path().join("schema.yaml");
+    let instance_path = dir.path().join("instance.yaml");
+    fs::write(
+        &schema_path,
+        r"type: object
+properties:
+  a:
+    type: string
+  b:
+    type: string
+",
+    )
+    .expect("write schema");
+    fs::write(
+        &instance_path,
+        r"a: 1
+b: 2
+",
+    )
+    .expect("write instance");
+
+    let output = Command::cargo_bin("ys")
+        .expect("ys binary")
+        .args([
+            "--json",
+            "-f",
+            schema_path.to_str().expect("utf8 path"),
+            instance_path.to_str().expect("utf8 path"),
+        ])
+        .output()
+        .expect("run ys");
+
+    assert!(!output.status.success(), "ys should fail validation");
+    let v: Value = serde_json::from_slice(&output.stdout).expect("stdout is JSON");
+    let arr = v.as_array().expect("stdout is JSON array");
+    assert!(
+        arr.len() > 1,
+        "expected multiple validation errors, got {}",
+        arr.len()
+    );
+    for entry in arr {
+        assert!(entry.get("path").is_some());
+        assert!(entry.get("error").is_some());
+    }
+}


### PR DESCRIPTION
## Summary

Adds machine-readable validation output to the `ys` CLI and improves how type mismatches are described in human-readable errors.

## Key changes

- **`--json` on `ys`**: On validation failure, prints a JSON array of errors to stdout with `index`, `line`, `col`, `path`, and `error` fields. Non-validation failures emit `{"error":"..."}` on stderr. Schema and load failures use the same JSON error shape when `--json` is set.
- **`humanize_yaml_data`**: Type-mismatch messages no longer use raw `Debug` for scalars; integers, floats, booleans, and strings are shown in a short, readable form (strings JSON-encoded with a `(string)` suffix).
- **Tests**: Cucumber scenario for `ys --json` with invalid fixtures; integration test `tests/ys_cli_json.rs`; feature expectations updated for new error text.

## Commits

- `feat: add JSON output for validation errors in CLI`
- `refactor: enhance error messages for type mismatches in validation`

Made with [Cursor](https://cursor.com)