### PR TITLE
CLI: validate from top-level $schema when -f is omitted

### DIFF
--- a/features/cli.feature
+++ b/features/cli.feature
@@ -18,6 +18,25 @@ Feature: CLI usage
       ```
     Then it should exit with status code 0
 
+  Scenario: Validation using top-level $schema instead of -f
+    When the following command is run:
+      ```
+      ys tests/fixtures/instance_with_dollar_schema_valid.yaml
+      ```
+    Then it should exit with status code 0
+
+  Scenario: Validation using $schema with an invalid instance
+    When the following command is run:
+      ```
+      ys tests/fixtures/instance_with_dollar_schema_invalid.yaml
+      ```
+    Then it should exit with status code 1
+    And stderr output should end with:
+      ```
+      [2:6] .foo: Expected a string, but got: 42 (int)
+      [3:6] .bar: Expected a number, but got: "I'm a string" (string)
+      ```
+
   Scenario: Basic validation with an invalid file
     When the following command is run:
       ```

--- a/src/bin/ys.rs
+++ b/src/bin/ys.rs
@@ -10,6 +10,7 @@ use serde_json::json;
 use url::Url;
 
 use yaml_schema::Engine;
+use yaml_schema::RootSchema;
 use yaml_schema::loader;
 use yaml_schema::validation::ValidationError;
 use yaml_schema::version;
@@ -26,6 +27,7 @@ pub struct Opts {
     pub command: Option<Commands>,
     /// Schema file(s) to load. The first is the root schema; additional schemas are
     /// pre-loaded for $ref resolution. May be specified multiple times (-f a.yaml -f b.yaml).
+    /// Omit when the instance YAML has a top-level string `$schema` (URL or path).
     #[arg(short = 'f', long = "schema")]
     pub schemas: Vec<String>,
     /// Specify this flag to exit (1) as soon as any error is encountered
@@ -102,71 +104,120 @@ fn schema_uri(path: &str) -> Result<String> {
     Ok(url.to_string())
 }
 
+fn insert_preloaded_entry(
+    preloaded: &mut HashMap<String, Rc<RootSchema>>,
+    schema: RootSchema,
+    uri: String,
+) -> Rc<RootSchema> {
+    let schema_rc = Rc::new(schema);
+    let key = schema_rc.cache_key(&uri);
+    // Insert under both `uri` and `key` when they differ so $ref resolution matches the CLI preload map.
+    if key != uri {
+        preloaded.insert(uri, Rc::clone(&schema_rc));
+    }
+    preloaded.insert(key, Rc::clone(&schema_rc));
+    schema_rc
+}
+
 /// The `ys validate` command
 fn command_validate(opts: Opts) -> Result<i32> {
     let json = opts.json;
-    if opts.schemas.is_empty() {
-        return Err(eyre::eyre!("No schema file(s) specified"));
-    }
-    if opts.file.is_none() {
-        return Err(eyre::eyre!("No YAML file specified"));
-    }
-
-    let root_path = opts.schemas.first().expect("No schema file(s) specified");
-    let root_schema = match loader::load_file(root_path) {
-        Ok(schema) => schema,
-        Err(e) => {
-            if json {
-                emit_json_error(&format!("Failed to read YAML schema file {root_path}: {e}"));
-            } else {
-                eprintln!("Failed to read YAML schema file: {root_path}");
-                log::error!("{e}");
-            }
-            return Ok(1);
-        }
+    let yaml_filename = match &opts.file {
+        Some(f) => f.as_str(),
+        None => return Err(eyre::eyre!("No YAML file specified")),
     };
 
-    let mut preloaded = HashMap::new();
-    for path in &opts.schemas {
-        let uri = match schema_uri(path) {
-            Ok(u) => u,
+    let yaml_contents = std::fs::read_to_string(yaml_filename)
+        .wrap_err_with(|| format!("Failed to read YAML file: {yaml_filename}"))?;
+
+    let (root_for_eval, preloaded) = if !opts.schemas.is_empty() {
+        let root_path = opts.schemas.first().expect("non-empty schemas");
+        let root_schema = match loader::load_file(root_path) {
+            Ok(schema) => schema,
             Err(e) => {
                 if json {
-                    emit_json_error(&format!("Failed to resolve schema path {path}: {e}"));
+                    emit_json_error(&format!("Failed to read YAML schema file {root_path}: {e}"));
                 } else {
-                    eprintln!("Failed to resolve schema path: {path}: {e}");
-                }
-                return Ok(1);
-            }
-        };
-        let schema = match loader::load_file(path) {
-            Ok(s) => s,
-            Err(e) => {
-                if json {
-                    emit_json_error(&format!("Failed to load schema file {path}: {e}"));
-                } else {
-                    eprintln!("Failed to load schema file: {path}");
+                    eprintln!("Failed to read YAML schema file: {root_path}");
                     log::error!("{e}");
                 }
                 return Ok(1);
             }
         };
-        let schema_rc = Rc::new(schema);
-        let key = schema_rc.cache_key(&uri);
-        // We need to insert the schema under both `uri` and `key` if they differ, because `cache_key` may normalize or canonicalize
-        // the schema reference (for example, following $id or resolving symlinks). This ensures both the original URI and any internal
-        // references will consistently resolve to the same Rc<Schema> instance during validation and $ref resolution.
-        if key != uri {
-            preloaded.insert(uri, Rc::clone(&schema_rc));
+
+        let mut preloaded = HashMap::new();
+        for path in &opts.schemas {
+            let uri = match schema_uri(path) {
+                Ok(u) => u,
+                Err(e) => {
+                    if json {
+                        emit_json_error(&format!("Failed to resolve schema path {path}: {e}"));
+                    } else {
+                        eprintln!("Failed to resolve schema path: {path}: {e}");
+                    }
+                    return Ok(1);
+                }
+            };
+            let schema = match loader::load_file(path) {
+                Ok(s) => s,
+                Err(e) => {
+                    if json {
+                        emit_json_error(&format!("Failed to load schema file {path}: {e}"));
+                    } else {
+                        eprintln!("Failed to load schema file: {path}");
+                        log::error!("{e}");
+                    }
+                    return Ok(1);
+                }
+            };
+            let _ = insert_preloaded_entry(&mut preloaded, schema, uri);
         }
-        preloaded.insert(key, schema_rc);
-    }
 
-    let yaml_filename = opts.file.as_ref().expect("No YAML file specified");
-    let yaml_contents = std::fs::read_to_string(yaml_filename)
-        .wrap_err_with(|| format!("Failed to read YAML file: {yaml_filename}"))?;
+        let root_rc = Rc::new(root_schema);
+        (root_rc, preloaded)
+    } else {
+        let instance_parent = Path::new(yaml_filename).parent().unwrap_or(Path::new("."));
+        let schema_ref = match loader::extract_dollar_schema_from_yaml(&yaml_contents) {
+            Ok(Some(s)) => s,
+            Ok(None) => {
+                return Err(eyre::eyre!(
+                    "No schema: pass -f/--schema or add a string `$schema` key to the YAML root mapping"
+                ));
+            }
+            Err(e) => {
+                return Err(eyre::eyre!(
+                    "Could not read `$schema` from instance YAML: {e}"
+                ));
+            }
+        };
 
-    match Engine::evaluate_with_schemas(&root_schema, &yaml_contents, opts.fail_fast, preloaded) {
+        let (root, uri) = match loader::load_root_schema_from_ref(&schema_ref, instance_parent) {
+            Ok(pair) => pair,
+            Err(e) => {
+                if json {
+                    emit_json_error(&format!(
+                        "Failed to load schema from $schema {schema_ref:?}: {e}"
+                    ));
+                } else {
+                    eprintln!("Failed to load schema from $schema: {schema_ref}");
+                    log::error!("{e}");
+                }
+                return Ok(1);
+            }
+        };
+
+        let mut preloaded = HashMap::new();
+        let root_rc = insert_preloaded_entry(&mut preloaded, root, uri);
+
+        (root_rc, preloaded)
+    };
+
+    match Engine::evaluate_with_schemas(
+        root_for_eval.as_ref(),
+        &yaml_contents,
+        opts.fail_fast,
+        preloaded,
+    ) {
         Ok(context) => {
             if context.has_errors() {
                 let errors = context.errors.borrow();

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -114,6 +114,76 @@ pub fn load_external_schema(doc_url: &str) -> Result<RootSchema> {
     }
 }
 
+/// Reads the first YAML document and returns the string value of a top-level `$schema` key, if present.
+///
+/// Returns `Ok(None)` when there is no document, the root is not a mapping, or `$schema` is absent.
+/// Returns an error if `$schema` is present but not a string.
+pub fn extract_dollar_schema_from_yaml(contents: &str) -> Result<Option<String>> {
+    let docs = MarkedYaml::load_from_str(contents).map_err(Error::YamlParsingError)?;
+    let Some(first) = docs.first() else {
+        return Ok(None);
+    };
+    match &first.data {
+        YamlData::Mapping(mapping) => {
+            let key = MarkedYaml::value_from_str("$schema");
+            match mapping.get(&key) {
+                Some(v) => Ok(Some(marked_yaml_to_string(v, "$schema must be a string")?)),
+                None => Ok(None),
+            }
+        }
+        _ => Ok(None),
+    }
+}
+
+/// Loads a root schema from a `$schema` reference: `http`/`https`/`file` URLs via [`load_external_schema`],
+/// otherwise as a filesystem path (relative paths are resolved against `instance_parent`).
+///
+/// Returns the loaded schema and a URI string suitable for [`RootSchema::cache_key`] fallback / preloaded map keys
+/// (matches `base_uri` after load).
+pub fn load_root_schema_from_ref(
+    schema_ref: &str,
+    instance_parent: &Path,
+) -> Result<(RootSchema, String)> {
+    let trimmed = schema_ref.trim();
+    if trimmed.is_empty() {
+        return Err(crate::generic_error!("$schema value is empty"));
+    }
+
+    let root = match ParseUrl::parse(trimmed) {
+        Ok(parsed) if matches!(parsed.scheme(), "http" | "https" | "file") => {
+            load_external_schema(trimmed)?
+        }
+        Ok(parsed) => {
+            return Err(crate::generic_error!(
+                "Unsupported URL scheme in $schema: {}",
+                parsed.scheme()
+            ));
+        }
+        Err(_) => {
+            let path = Path::new(trimmed);
+            let resolved = if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                instance_parent.join(path)
+            };
+            let path_str = resolved
+                .to_str()
+                .ok_or_else(|| Error::GenericError("Non-UTF-8 schema path".to_string()))?;
+            load_file(path_str)?
+        }
+    };
+
+    let fallback = root
+        .base_uri
+        .as_ref()
+        .map(|u| u.to_string())
+        .ok_or_else(|| {
+            Error::GenericError("Internal error: loaded schema missing base URI".to_string())
+        })?;
+
+    Ok((root, fallback))
+}
+
 /// Fetches content from a URL. Returns the response body as a String and the request URL.
 ///
 /// The HTTP call runs on a dedicated OS thread so that `reqwest::blocking`
@@ -578,6 +648,50 @@ mod tests {
         let result = root_schema.validate(&context, value);
         assert!(result.is_ok());
         assert!(!context.has_errors());
+    }
+
+    #[test]
+    fn extract_dollar_schema_from_mapping() {
+        let yaml = "$schema: ./x.yaml\nfoo: 1\n";
+        assert_eq!(
+            extract_dollar_schema_from_yaml(yaml).unwrap(),
+            Some("./x.yaml".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_dollar_schema_missing() {
+        assert_eq!(extract_dollar_schema_from_yaml("foo: 1\n").unwrap(), None);
+    }
+
+    #[test]
+    fn extract_dollar_schema_non_mapping_root() {
+        assert_eq!(extract_dollar_schema_from_yaml("- a\n").unwrap(), None);
+    }
+
+    #[test]
+    fn extract_dollar_schema_not_string_errors() {
+        let result = extract_dollar_schema_from_yaml("$schema: 42\n");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn load_root_schema_from_ref_relative_path() {
+        let dir = std::env::temp_dir().join(format!("yaml_schema_ref_test_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let schema_path = dir.join("sch.yaml");
+        std::fs::write(
+            &schema_path,
+            "type: object\nproperties:\n  a:\n    type: string\n",
+        )
+        .expect("write schema");
+        let (root, uri) = load_root_schema_from_ref("sch.yaml", &dir).expect("load");
+        assert!(uri.starts_with("file://"));
+        let YamlSchema::Subschema(sub) = &root.schema else {
+            panic!("expected Subschema");
+        };
+        assert_eq!(sub.r#type, SchemaType::new("object"));
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/tests/fixtures/instance_with_dollar_schema_invalid.yaml
+++ b/tests/fixtures/instance_with_dollar_schema_invalid.yaml
@@ -1,0 +1,3 @@
+$schema: schema.yaml
+foo: 42
+bar: "I'm a string"

--- a/tests/fixtures/instance_with_dollar_schema_valid.yaml
+++ b/tests/fixtures/instance_with_dollar_schema_valid.yaml
@@ -1,0 +1,3 @@
+$schema: schema.yaml
+foo: "I'm a string"
+bar: 42

--- a/tests/ys_cli_json.rs
+++ b/tests/ys_cli_json.rs
@@ -51,3 +51,48 @@ b: 2
         assert!(entry.get("error").is_some());
     }
 }
+
+#[test]
+fn validation_without_f_uses_dollar_schema_and_json_output() {
+    let dir = tempdir().expect("tempdir");
+    let schema_path = dir.path().join("schema.yaml");
+    let instance_path = dir.path().join("instance.yaml");
+    fs::write(
+        &schema_path,
+        r"type: object
+properties:
+  a:
+    type: string
+  b:
+    type: string
+",
+    )
+    .expect("write schema");
+    fs::write(
+        &instance_path,
+        r"$schema: schema.yaml
+a: 1
+b: 2
+",
+    )
+    .expect("write instance");
+
+    let output = Command::cargo_bin("ys")
+        .expect("ys binary")
+        .args(["--json", instance_path.to_str().expect("utf8 path")])
+        .output()
+        .expect("run ys");
+
+    assert!(!output.status.success(), "ys should fail validation");
+    let v: Value = serde_json::from_slice(&output.stdout).expect("stdout is JSON");
+    let arr = v.as_array().expect("stdout is JSON array");
+    assert!(
+        arr.len() > 1,
+        "expected multiple validation errors, got {}",
+        arr.len()
+    );
+    for entry in arr {
+        assert!(entry.get("path").is_some());
+        assert!(entry.get("error").is_some());
+    }
+}

--- a/yaml-schema.yaml
+++ b/yaml-schema.yaml
@@ -1,4 +1,4 @@
-$schema: https://json-schema.org/draft/2020-12/schema
+$schema: https://yaml-schema.net/yaml-schema.yaml
 $id: https://yaml-schema.net/draft/2025-11/meta-schema
 title: YAML Schema meta-schema
 description: Meta-schema for YAML Schema, based on JSON Schema meta-schema


### PR DESCRIPTION
## Summary

The `ys` CLI can validate an instance YAML file without `-f/--schema` when the document has a top-level string `$schema` key. The value is treated as a URL (http/https/file) or a filesystem path; relative paths resolve against the instance file's directory.

## Key changes

- **Loader**: `extract_dollar_schema_from_yaml` reads the first document's root `$schema`; `load_root_schema_from_ref` loads the schema from URL or path with unit tests.
- **CLI** (`ys validate`): If no `-f` is given, load the root schema from `$schema`; refactored preloaded map insertion into `insert_preloaded_entry`.
- **Tests**: Cucumber scenarios and fixtures for valid/invalid instances; integration test for `--json` without `-f`.
- **Meta-schema**: `yaml-schema.yaml` `$schema` now points at `https://yaml-schema.net/yaml-schema.yaml` (replacing the JSON Schema draft URL).

## Stats

7 files changed, +279 / -44 lines.

Made with [Cursor](https://cursor.com)