### PR TITLE
fix: suppress spurious ERROR log from speculative oneOf branches

### DIFF
--- a/features/one_of.feature
+++ b/features/one_of.feature
@@ -48,3 +48,43 @@ Feature: oneOf
       ```
       type: boolean
       ```
+
+  Scenario: oneOf with string and object branches
+    Given a YAML schema:
+      ```
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            oneOf:
+              - type: string
+                minLength: 1
+              - type: object
+                required:
+                  - name
+                properties:
+                  name:
+                    type: string
+      ```
+    Then it should accept:
+      ```
+      items:
+        - hello
+        - name: world
+      ```
+    And it should accept:
+      ```
+      items:
+        - just_a_string
+      ```
+    And it should accept:
+      ```
+      items:
+        - name: structured
+      ```
+    But it should NOT accept:
+      ```
+      items:
+        - ""
+      ```

--- a/src/validation/objects.rs
+++ b/src/validation/objects.rs
@@ -2,7 +2,7 @@
 use std::collections::HashSet;
 
 use hashlink::LinkedHashMap;
-use log::{debug, error};
+use log::debug;
 
 use crate::Error;
 use crate::Result;
@@ -25,7 +25,7 @@ impl Validator for ObjectSchema {
                 "[ObjectSchema] {} Expected an object, but got: {data:?}",
                 format_marker(&value.span.start)
             );
-            error!("{error_message}");
+            debug!("{error_message}");
             context.add_error(value, error_message);
             Ok(())
         }


### PR DESCRIPTION
## Summary

- `ObjectSchema::validate()` used `log::error!()` when a non-object value was tested against an object schema. When the object branch is one arm of a `oneOf`, this fires during a speculative validation attempt that the `oneOf` logic correctly rejects — but the `error!()` has already written to stderr, producing misleading output on valid documents.
- Downgraded to `debug!()`. The validation failure is still recorded via `context.add_error()` and surfaced if no `oneOf` branch matches.
- Added a Cucumber scenario for `oneOf` with mixed string/object branches (the pattern that exposed this).

## Reproducer

Schema:
```yaml
type: object
properties:
  items:
    type: array
    items:
      oneOf:
        - type: string
          minLength: 1
        - type: object
          required: [name]
          properties:
            name:
              type: string
```

Instance (valid):
```yaml
items:
  - hello
  - name: world
```

**Before** (v0.9.1): exit 0 but stderr shows:
```
[ERROR yaml_schema::validation::objects] [ObjectSchema] [2, 4] Expected an object, but got: Value(String("hello"))
```

**After**: exit 0, no stderr output.

## Test plan

- [x] All 185 existing tests pass (`cargo test`)
- [x] New `one_of.feature` scenario covers string-or-object `oneOf` (accept and reject cases)
- [x] Manual verification with reproducer above