### PR TITLE
Add YAML-only propertyKeys for mapping key validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here. Release notes for publi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+
+- `propertyKeys` — YAML-only object keyword: a subschema validated against each mapping **key** node (scalar); `propertyNames` remains JSON-compatible on the string projection of keys.
+
 ## [0.9.1] - 2026-03-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ expressed as YAML.
 
 When writing schemas or instances in YAML, remember that **mapping keys are parsed by YAML first**. Unquoted keys such as `1` become a number; keys that start with `@`, `#`, or other special characters may be invalid or require [quoting](https://stackoverflow.com/questions/19109912/do-i-need-quotes-for-strings-in-yaml). Use explicit quotes (e.g. `"@id"`, `"1"`) when the property name must be that exact string. See also [issue #62](https://github.com/yaml-schema/yaml-schema/issues/62).
 
+**JSON Schema vs YAML:** JSON object keys are always strings. YAML allows other **scalar** mapping keys (e.g. integers). The `propertyNames` keyword stays JSON-compatible: it applies to the canonical string form of the key. The **`propertyKeys`** keyword is a YAML Schema extension: use a normal subschema (e.g. `type: integer`, `enum`) to validate each **key node** as YAML data. When both are present, `propertyKeys` runs first, then `propertyNames`. See the [Types](https://yaml-schema.net/features/types.html) documentation for details.
+
 ## Example Usage
 
 Given a `schema.yaml` file containing:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ expressed as YAML.
 
 **yaml-schema** is both a Rust library _and_ an executable.
 
+## Documentation
+
+See detailed documentation at [https://yaml-schema.net/](https://yaml-schema.net/).
+
 When writing schemas or instances in YAML, remember that **mapping keys are parsed by YAML first**. Unquoted keys such as `1` become a number; keys that start with `@`, `#`, or other special characters may be invalid or require [quoting](https://stackoverflow.com/questions/19109912/do-i-need-quotes-for-strings-in-yaml). Use explicit quotes (e.g. `"@id"`, `"1"`) when the property name must be that exact string. See also [issue #62](https://github.com/yaml-schema/yaml-schema/issues/62).
 
 **JSON Schema vs YAML:** JSON object keys are always strings. YAML allows other **scalar** mapping keys (e.g. integers). The `propertyNames` keyword stays JSON-compatible: it applies to the canonical string form of the key. The **`propertyKeys`** keyword is a YAML Schema extension: use a normal subschema (e.g. `type: integer`, `enum`) to validate each **key node** as YAML data. When both are present, `propertyKeys` runs first, then `propertyNames`. See the [Types](https://yaml-schema.net/features/types.html) documentation for details.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ expressed as YAML.
 
 **yaml-schema** is both a Rust library _and_ an executable.
 
+When writing schemas or instances in YAML, remember that **mapping keys are parsed by YAML first**. Unquoted keys such as `1` become a number; keys that start with `@`, `#`, or other special characters may be invalid or require [quoting](https://stackoverflow.com/questions/19109912/do-i-need-quotes-for-strings-in-yaml). Use explicit quotes (e.g. `"@id"`, `"1"`) when the property name must be that exact string. See also [issue #62](https://github.com/yaml-schema/yaml-schema/issues/62).
+
 ## Example Usage
 
 Given a `schema.yaml` file containing:

--- a/features/objects.feature
+++ b/features/objects.feature
@@ -40,6 +40,38 @@ Feature: Object types
       ["An", "array", "not", "an", "object"]
       ```
 
+  Scenario: Schema properties with numeric keys
+    Given a YAML schema:
+      ```
+      type: object
+      properties:
+        1:
+          type: string
+      ```
+    Then it should accept:
+      ```
+      1: m
+      ```
+
+  Scenario: Quoted mapping keys in schema and instance
+    Given a YAML schema:
+      ```
+      type: object
+      properties:
+        "@leading":
+          type: string
+        "#tag":
+          type: string
+        "-dash key":
+          type: string
+      ```
+    Then it should accept:
+      ```
+      "@leading": hello
+      "#tag": world
+      "-dash key": okay
+      ```
+
   Scenario: properties
     Given a YAML schema:
       ```
@@ -370,6 +402,8 @@ Feature: Object types
       email: null
       ```
 
+  # propertyNames matches the resolved string key; YAML quotes do not change it.
+  # Keys starting with @ or #, or ambiguous numeric-like labels, must be quoted in YAML to parse.
   Scenario: Property names
     Given a YAML schema:
       ```

--- a/features/objects.feature
+++ b/features/objects.feature
@@ -421,6 +421,59 @@ Feature: Object types
       ```
     And the error message should be "[1:1] .: Property name '-001 invalid' does not match pattern '^[A-Za-z_][A-Za-z0-9_]*$'"
 
+  # propertyKeys validates each mapping key as a YAML scalar (YAML extension; not JSON Schema).
+  Scenario: Property keys integer
+    Given a YAML schema:
+      ```
+      type: object
+      propertyKeys:
+        type: integer
+      ```
+    Then it should accept:
+      ```
+      1: one
+      2: two
+      ```
+    But it should NOT accept:
+      ```
+      hello: world
+      ```
+
+  Scenario: Property keys string enum on key
+    Given a YAML schema:
+      ```
+      type: object
+      propertyKeys:
+        type: string
+        enum:
+          - alpha
+          - beta
+      ```
+    Then it should accept:
+      ```
+      alpha: 1
+      beta: 2
+      ```
+    But it should NOT accept:
+      ```
+      gamma: 3
+      ```
+
+  Scenario: Property keys and property names together
+    Given a YAML schema:
+      ```
+      type: object
+      propertyKeys:
+        type: integer
+      propertyNames:
+        pattern: "^a$"
+      ```
+    Then it should NOT accept:
+      ```
+      1: ok
+      ```
+    And the error message should be "[1:1] .: Property name '1' does not match pattern '^a$'"
+
   Scenario: Size
     Given a YAML schema:
       ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub use validation::Validator;
 
 use utils::format_marker;
 
-use crate::loader::marked_yaml_to_string;
+use crate::loader::marked_yaml_mapping_key_to_string;
 
 // Returns the library version, which reflects the crate version
 pub fn version() -> String {
@@ -218,7 +218,7 @@ impl<'a> TryFrom<&YamlData<'a, MarkedYaml<'a>>> for ConstValue {
             YamlData::Mapping(mapping) => {
                 let mut obj = LinkedHashMap::new();
                 for (key, val) in mapping.iter() {
-                    let key_str = marked_yaml_to_string(key, "const object key must be a string")?;
+                    let key_str = marked_yaml_mapping_key_to_string(key)?;
                     let val_cv: ConstValue = val.try_into()?;
                     obj.insert(key_str, val_cv);
                 }

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -18,6 +18,7 @@ use crate::RootSchema;
 use crate::schemas::BooleanOrSchema;
 use crate::schemas::YamlSchema;
 use crate::utils::format_marker;
+use crate::utils::scalar_to_string;
 use crate::utils::try_unwrap_saphyr_scalar;
 
 /// Load a YAML schema from a file.
@@ -255,6 +256,22 @@ pub fn marked_yaml_to_string<S: Into<String> + Copy>(yaml: &MarkedYaml, msg: S) 
         Ok(s.to_string())
     } else {
         Err(Error::ExpectedScalar(msg.into()))
+    }
+}
+
+/// Property name / mapping key as a string, matching instance validation (`scalar_to_string`).
+///
+/// YAML may parse unquoted keys as integers or floats; quote the key in YAML if you need a specific
+/// string label (e.g. `"1"` vs `1`).
+pub fn marked_yaml_mapping_key_to_string(yaml: &MarkedYaml) -> Result<String> {
+    if let YamlData::Value(scalar) = &yaml.data {
+        Ok(scalar_to_string(scalar))
+    } else {
+        Err(expected_scalar!(
+            "[{}] Expected a scalar mapping key, got: {:?}",
+            format_marker(&yaml.span.start),
+            yaml
+        ))
     }
 }
 

--- a/src/schemas/object.rs
+++ b/src/schemas/object.rs
@@ -13,6 +13,7 @@ use crate::Error;
 use crate::Result;
 use crate::YamlSchema;
 use crate::loader::load_integer_marked;
+use crate::loader::marked_yaml_mapping_key_to_string;
 use crate::schemas::BooleanOrSchema;
 use crate::schemas::StringSchema;
 use crate::utils::format_annotated_mapping;
@@ -190,22 +191,15 @@ fn load_properties_marked<'r>(value: &MarkedYaml<'r>) -> Result<LinkedHashMap<St
     if let YamlData::Mapping(mapping) = &value.data {
         let mut properties = LinkedHashMap::new();
         for (key, value) in mapping.iter() {
-            if let YamlData::Value(Scalar::String(key)) = &key.data {
-                if value.data.is_mapping() {
-                    let schema: YamlSchema = value.try_into()?;
-                    properties.insert(key.to_string(), schema);
-                } else {
-                    return Err(generic_error!(
-                        "properties: Expected a mapping for \"{}\", but got: {:?}",
-                        key,
-                        value
-                    ));
-                }
+            let key_string = marked_yaml_mapping_key_to_string(key)?;
+            if value.data.is_mapping() {
+                let schema: YamlSchema = value.try_into()?;
+                properties.insert(key_string, schema);
             } else {
                 return Err(generic_error!(
-                    "{} Expected a string key, but got: {:?}",
-                    format_marker(&key.span.start),
-                    key
+                    "properties: Expected a mapping for \"{}\", but got: {:?}",
+                    key_string,
+                    value
                 ));
             }
         }
@@ -223,24 +217,17 @@ fn load_pattern_properties_marked<'r>(value: &MarkedYaml<'r>) -> Result<Vec<Patt
     if let YamlData::Mapping(mapping) = &value.data {
         let mut pattern_properties = Vec::new();
         for (key, value) in mapping.iter() {
-            if let YamlData::Value(Scalar::String(pattern)) = &key.data {
-                let regex = Regex::new(pattern.as_ref())
-                    .map_err(|_e| Error::InvalidRegularExpression(pattern.to_string()))?;
-                if value.data.is_mapping() {
-                    let schema: YamlSchema = value.try_into()?;
-                    pattern_properties.push(PatternProperty { regex, schema });
-                } else {
-                    return Err(generic_error!(
-                        "patternProperties: Expected a mapping for \"{}\", but got: {:?}",
-                        pattern,
-                        value
-                    ));
-                }
+            let pattern = marked_yaml_mapping_key_to_string(key)?;
+            let regex = Regex::new(pattern.as_ref())
+                .map_err(|_e| Error::InvalidRegularExpression(pattern.clone()))?;
+            if value.data.is_mapping() {
+                let schema: YamlSchema = value.try_into()?;
+                pattern_properties.push(PatternProperty { regex, schema });
             } else {
                 return Err(generic_error!(
-                    "{} Expected a string key, but got: {:?}",
-                    format_marker(&key.span.start),
-                    key
+                    "patternProperties: Expected a mapping for \"{}\", but got: {:?}",
+                    pattern,
+                    value
                 ));
             }
         }
@@ -260,18 +247,12 @@ fn load_dependent_required_marked<'r>(
     if let YamlData::Mapping(mapping) = &value.data {
         let mut out = LinkedHashMap::new();
         for (key, val) in mapping.iter() {
-            let YamlData::Value(Scalar::String(trigger)) = &key.data else {
-                return Err(generic_error!(
-                    "{} dependentRequired: Expected string key, got: {:?}",
-                    format_marker(&key.span.start),
-                    key.data
-                ));
-            };
+            let trigger = marked_yaml_mapping_key_to_string(key)?;
             let YamlData::Sequence(values) = &val.data else {
                 return Err(unsupported_type!(
                     "{} dependentRequired: Expected array for key {:?}, got: {:?}",
                     format_marker(&val.span.start),
-                    trigger.as_ref(),
+                    trigger,
                     val.data
                 ));
             };
@@ -291,12 +272,12 @@ fn load_dependent_required_marked<'r>(
                         "{} dependentRequired: duplicate property name {:?} for trigger {:?}",
                         format_marker(&v.span.start),
                         dep,
-                        trigger.as_ref()
+                        trigger
                     ));
                 }
                 deps.push(dep);
             }
-            out.insert(trigger.to_string(), deps);
+            out.insert(trigger, deps);
         }
         Ok(out)
     } else {
@@ -314,22 +295,16 @@ fn load_dependent_schemas_marked<'r>(
     if let YamlData::Mapping(mapping) = &value.data {
         let mut out = LinkedHashMap::new();
         for (key, val) in mapping.iter() {
-            let YamlData::Value(Scalar::String(name)) = &key.data else {
-                return Err(generic_error!(
-                    "{} dependentSchemas: Expected string key, got: {:?}",
-                    format_marker(&key.span.start),
-                    key.data
-                ));
-            };
+            let name = marked_yaml_mapping_key_to_string(key)?;
             if !val.data.is_mapping() {
                 return Err(generic_error!(
                     "dependentSchemas: Expected a mapping for {:?}, but got: {:?}",
-                    name.as_ref(),
+                    name,
                     val.data
                 ));
             }
             let schema: YamlSchema = val.try_into()?;
-            out.insert(name.to_string(), schema);
+            out.insert(name, schema);
         }
         Ok(out)
     } else {
@@ -565,6 +540,21 @@ office_number: 201",
                 .as_ref()
                 .unwrap()
                 .contains_key("const")
+        );
+    }
+
+    #[test]
+    fn test_properties_numeric_mapping_key_loads() {
+        let yaml = "
+        type: object
+        properties:
+          1:
+            type: string";
+        let doc = MarkedYaml::load_from_str(yaml).unwrap();
+        let os: ObjectSchema = doc.first().unwrap().try_into().unwrap();
+        assert!(
+            os.properties.as_ref().unwrap().contains_key("1"),
+            "unquoted numeric mapping key should become string property name \"1\""
         );
     }
 

--- a/src/schemas/object.rs
+++ b/src/schemas/object.rs
@@ -41,6 +41,8 @@ pub struct ObjectSchema {
     pub additional_properties: Option<BooleanOrSchema>,
     pub pattern_properties: Option<Vec<PatternProperty>>,
     pub property_names: Option<StringSchema>,
+    /// YAML extension: subschema applied to each mapping **key** node (scalar), not JSON Schema.
+    pub property_keys: Option<YamlSchema>,
     pub min_properties: Option<usize>,
     pub max_properties: Option<usize>,
     /// JSON Schema `dependentRequired`: when a trigger property is present, all listed properties must be present.
@@ -119,6 +121,16 @@ impl<'r> TryFrom<&AnnotatedMapping<'r, MarkedYaml<'r>>> for ObjectSchema {
                         } else {
                             return Err(unsupported_type!(
                                 "propertyNames: Expected a mapping, but got: {:?}",
+                                value
+                            ));
+                        }
+                    }
+                    "propertyKeys" => {
+                        if value.data.is_mapping() {
+                            object_schema.property_keys = Some(value.try_into()?);
+                        } else {
+                            return Err(unsupported_type!(
+                                "propertyKeys: Expected a mapping (subschema), but got: {:?}",
                                 value
                             ));
                         }
@@ -428,6 +440,11 @@ impl ObjectSchemaBuilder {
         self.0.property_names = Some(property_names);
         self
     }
+
+    pub fn property_keys(&mut self, schema: YamlSchema) -> &mut Self {
+        self.0.property_keys = Some(schema);
+        self
+    }
 }
 
 #[cfg(test)]
@@ -556,6 +573,69 @@ office_number: 201",
             os.properties.as_ref().unwrap().contains_key("1"),
             "unquoted numeric mapping key should become string property name \"1\""
         );
+    }
+
+    #[test]
+    fn test_property_keys_loads_integer_schema() {
+        let yaml = r#"
+        type: object
+        propertyKeys:
+          type: integer
+        "#;
+        let doc = MarkedYaml::load_from_str(yaml).unwrap();
+        let os: ObjectSchema = doc.first().unwrap().try_into().unwrap();
+        assert!(
+            os.property_keys.is_some(),
+            "propertyKeys subschema should be loaded"
+        );
+    }
+
+    #[test]
+    fn test_property_keys_rejects_non_mapping() {
+        let yaml = r#"
+        type: object
+        propertyKeys: integer
+        "#;
+        let doc = MarkedYaml::load_from_str(yaml).unwrap();
+        assert!(ObjectSchema::try_from(doc.first().unwrap()).is_err());
+    }
+
+    #[test]
+    fn test_property_keys_validation_accepts_integer_keys() {
+        let yaml = r#"
+        type: object
+        propertyKeys:
+          type: integer
+        "#;
+        let schema: ObjectSchema = MarkedYaml::load_from_str(yaml)
+            .unwrap()
+            .first()
+            .unwrap()
+            .try_into()
+            .unwrap();
+        let inst = MarkedYaml::load_from_str("1: a\n2: b").unwrap();
+        let ctx = crate::Context::default();
+        schema.validate(&ctx, inst.first().unwrap()).unwrap();
+        assert!(!ctx.has_errors());
+    }
+
+    #[test]
+    fn test_property_keys_validation_rejects_string_key() {
+        let yaml = r#"
+        type: object
+        propertyKeys:
+          type: integer
+        "#;
+        let schema: ObjectSchema = MarkedYaml::load_from_str(yaml)
+            .unwrap()
+            .first()
+            .unwrap()
+            .try_into()
+            .unwrap();
+        let inst = MarkedYaml::load_from_str("x: 1").unwrap();
+        let ctx = crate::Context::default();
+        schema.validate(&ctx, inst.first().unwrap()).unwrap();
+        assert!(ctx.has_errors(), "non-integer keys should surface errors");
     }
 
     #[test]

--- a/src/schemas/yaml_schema.rs
+++ b/src/schemas/yaml_schema.rs
@@ -17,6 +17,7 @@ use crate::Result;
 use crate::Validator;
 use crate::loader::load_boolean_or_schema_marked;
 use crate::loader::load_external_schema;
+use crate::loader::marked_yaml_mapping_key_to_string;
 use crate::loader::marked_yaml_to_string;
 use crate::schemas::AllOfSchema;
 use crate::schemas::AnyOfSchema;
@@ -416,7 +417,7 @@ fn try_load_defs<'r>(marked_yaml: &MarkedYaml<'r>) -> Result<LinkedHashMap<Strin
         mapping
             .iter()
             .try_fold(LinkedHashMap::new(), |mut acc, (key, value)| {
-                let key = marked_yaml_to_string(key, "key must be a string")?;
+                let key = marked_yaml_mapping_key_to_string(key)?;
                 acc.insert(key, value.try_into()?);
                 Ok(acc)
             })

--- a/src/validation/objects.rs
+++ b/src/validation/objects.rs
@@ -163,7 +163,12 @@ impl ObjectSchema {
                     context.record_evaluated_property(&key_string);
                 }
             }
-            // Finally, we check if it matches property_names
+            // propertyKeys: YAML extension — validate each key node as an instance (before propertyNames).
+            if let Some(property_keys) = &self.property_keys {
+                let keys_context = context.append_path(&key_string);
+                property_keys.validate(&keys_context, k)?;
+            }
+            // propertyNames: string projection + pattern (JSON Schema compatible).
             if let Some(property_names) = &self.property_names {
                 if let Some(re) = &property_names.pattern {
                     debug!("Regex for property names: {}", re.as_str());

--- a/yaml-schema.yaml
+++ b/yaml-schema.yaml
@@ -80,6 +80,11 @@ $defs:
         patternProperties:
           "^[a-zA-Z0-9_-]+$":
             $ref: "#/$defs/schema"
+      propertyKeys:
+        description: >-
+          YAML-only extension (not JSON Schema): subschema validated against each mapping
+          key node as a YAML value.
+        $ref: "#/$defs/schema"
   array_of_schemas:
     description: >-
       An array of schemas
@@ -159,6 +164,11 @@ properties:
     patternProperties:
       "^[a-zA-Z0-9_-]+$":
         $ref: "#/$defs/schema"
+  propertyKeys:
+    description: >-
+      YAML-only extension (not JSON Schema): subschema validated against each mapping key
+      node as a YAML value.
+    $ref: "#/$defs/schema"
   unevaluatedProperties:
     description: >-
       JSON Schema 2020-12 unevaluated vocabulary. Applies to object properties not already


### PR DESCRIPTION
## Summary
- Add `propertyKeys` (YAML-only extension) to validate object mapping keys as YAML scalar nodes, complementary to JSON-compatible `propertyNames`.
- Allow non-string YAML mapping keys in object-related schema keywords by stringifying scalars consistently (e.g. `properties`, `patternProperties`, `$defs`).
- Document YAML quoting pitfalls and add BDD + unit tests covering numeric/special-character keys.

## Test plan
- `cargo test`

Made with [Cursor](https://cursor.com)