### PR TITLE
Implement full propertyNames subschema validation for mapping keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- `propertyKeys` — YAML-only object keyword: a subschema validated against each mapping **key** node (scalar); `propertyNames` remains JSON-compatible on the string projection of keys.
+- `propertyNames` — full subschema validation for mapping keys. When no `type` is provided, the subschema is treated as implicit `type: string` and validates the canonical string form of each key. Non-string types (e.g. `integer`, `enum`) validate the YAML key node directly.
 
 ## [0.9.1] - 2026-03-21
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ See detailed documentation at [https://yaml-schema.net/](https://yaml-schema.net
 
 When writing schemas or instances in YAML, remember that **mapping keys are parsed by YAML first**. Unquoted keys such as `1` become a number; keys that start with `@`, `#`, or other special characters may be invalid or require [quoting](https://stackoverflow.com/questions/19109912/do-i-need-quotes-for-strings-in-yaml). Use explicit quotes (e.g. `"@id"`, `"1"`) when the property name must be that exact string. See also [issue #62](https://github.com/yaml-schema/yaml-schema/issues/62).
 
-**JSON Schema vs YAML:** JSON object keys are always strings. YAML allows other **scalar** mapping keys (e.g. integers). The `propertyNames` keyword stays JSON-compatible: it applies to the canonical string form of the key. The **`propertyKeys`** keyword is a YAML Schema extension: use a normal subschema (e.g. `type: integer`, `enum`) to validate each **key node** as YAML data. When both are present, `propertyKeys` runs first, then `propertyNames`. See the [Types](https://yaml-schema.net/features/types.html) documentation for details.
+**JSON Schema vs YAML:** JSON object keys are always strings. YAML allows other **scalar** mapping keys (e.g. integers). The `propertyNames` keyword validates each mapping key against a subschema. When no `type` is provided, the subschema is treated as `type: string` and validates the canonical string form of the key (JSON Schema compatible). When a non-string `type` is specified (e.g. `integer`, `enum`), the YAML key node is validated directly. See the [Types](https://yaml-schema.net/features/types.html) documentation for details.
 
 ## Example Usage
 

--- a/features/objects.feature
+++ b/features/objects.feature
@@ -401,32 +401,37 @@ Feature: Object types
       address: Henley Street, Stratford-upon-Avon, Warwickshire, England
       email: null
       ```
-
   # propertyNames matches the resolved string key; YAML quotes do not change it.
   # Keys starting with @ or #, or ambiguous numeric-like labels, must be quoted in YAML to parse.
+
   Scenario: Property names
     Given a YAML schema:
       ```
       type: object
       propertyNames:
-        pattern: "^[A-Za-z_][A-Za-z0-9_]*$"
+        pattern: "^[A-Za-z0-9_]*$"
       ```
     Then it should accept:
       ```
       _a_proper_token_001: "value"
       ```
+    # integer keys are valid
+    And it should accept:
+      ```
+      1: "value"
+      ```
     But it should NOT accept:
       ```
       -001 invalid: "value"
       ```
-    And the error message should be "[1:1] .: Property name '-001 invalid' does not match pattern '^[A-Za-z_][A-Za-z0-9_]*$'"
+    And the error message should be "[1:1] .-001 invalid: String does not match regular expression ^[A-Za-z0-9_]*$!"
+  # propertyNames with non-string type validates each mapping key as a YAML scalar.
 
-  # propertyKeys validates each mapping key as a YAML scalar (YAML extension; not JSON Schema).
-  Scenario: Property keys integer
+  Scenario: Property names integer keys
     Given a YAML schema:
       ```
       type: object
-      propertyKeys:
+      propertyNames:
         type: integer
       ```
     Then it should accept:
@@ -439,11 +444,11 @@ Feature: Object types
       hello: world
       ```
 
-  Scenario: Property keys string enum on key
+  Scenario: Property names string enum on key
     Given a YAML schema:
       ```
       type: object
-      propertyKeys:
+      propertyNames:
         type: string
         enum:
           - alpha
@@ -459,20 +464,28 @@ Feature: Object types
       gamma: 3
       ```
 
-  Scenario: Property keys and property names together
+  Scenario: Property names subschema
     Given a YAML schema:
       ```
       type: object
-      propertyKeys:
-        type: integer
       propertyNames:
-        pattern: "^a$"
+        oneOf:
+          - type: string
+            enum: [alpha, beta]
+          - type: integer
+          - type: boolean
       ```
-    Then it should NOT accept:
+    Then it should accept:
       ```
-      1: ok
+      alpha: 1
+      beta: 2
+      1: one
+      true: yes
       ```
-    And the error message should be "[1:1] .: Property name '1' does not match pattern '^a$'"
+    But it should NOT accept:
+      ```
+      gamma: 3
+      ```
 
   Scenario: Size
     Given a YAML schema:

--- a/features/one_of.feature
+++ b/features/one_of.feature
@@ -88,3 +88,27 @@ Feature: oneOf
       items:
         - ""
       ```
+
+  Scenario: oneOf for propertyNames
+    Given a YAML schema:
+      ```
+      type: array
+      items:
+        oneOf:
+          - type: string
+            enum: [alpha, beta]
+          - type: integer
+          - type: boolean
+      ```
+    Then it should accept:
+      ```
+      - alpha
+      - beta
+      - 1
+      - true
+      ```
+    But it should NOT accept:
+      ```
+      - gamma
+      ```
+    And the error message should be "[1:3] .: None of the schemas in `oneOf` matched!"

--- a/src/schemas/object.rs
+++ b/src/schemas/object.rs
@@ -15,7 +15,6 @@ use crate::YamlSchema;
 use crate::loader::load_integer_marked;
 use crate::loader::marked_yaml_mapping_key_to_string;
 use crate::schemas::BooleanOrSchema;
-use crate::schemas::StringSchema;
 use crate::utils::format_annotated_mapping;
 use crate::utils::format_marker;
 use crate::utils::linked_hash_map;
@@ -40,9 +39,8 @@ pub struct ObjectSchema {
     pub required: Option<Vec<String>>,
     pub additional_properties: Option<BooleanOrSchema>,
     pub pattern_properties: Option<Vec<PatternProperty>>,
-    pub property_names: Option<StringSchema>,
-    /// YAML extension: subschema applied to each mapping **key** node (scalar), not JSON Schema.
-    pub property_keys: Option<YamlSchema>,
+    /// JSON Schema `propertyNames`: subschema validated against each mapping key.
+    pub property_names: Option<YamlSchema>,
     pub min_properties: Option<usize>,
     pub max_properties: Option<usize>,
     /// JSON Schema `dependentRequired`: when a trigger property is present, all listed properties must be present.
@@ -101,36 +99,11 @@ impl<'r> TryFrom<&AnnotatedMapping<'r, MarkedYaml<'r>>> for ObjectSchema {
                             Some(load_pattern_properties_marked(value)?);
                     }
                     "propertyNames" => {
-                        if let YamlData::Mapping(mapping) = &value.data {
-                            let pattern_key = MarkedYaml::value_from_str("pattern");
-                            if !mapping.contains_key(&pattern_key) {
-                                return Err(generic_error!(
-                                    "{} propertyNames: Missing required key: pattern",
-                                    format_marker(&value.span.start)
-                                ));
-                            }
-                            if let Some(v) = &mapping.get(&pattern_key)
-                                && let YamlData::Value(Scalar::String(pattern)) = &v.data
-                            {
-                                let regex = Regex::new(pattern.as_ref()).map_err(|_e| {
-                                    Error::InvalidRegularExpression(pattern.to_string())
-                                })?;
-                                object_schema.property_names =
-                                    Some(StringSchema::builder().pattern(regex).build());
-                            }
-                        } else {
-                            return Err(unsupported_type!(
-                                "propertyNames: Expected a mapping, but got: {:?}",
-                                value
-                            ));
-                        }
-                    }
-                    "propertyKeys" => {
                         if value.data.is_mapping() {
-                            object_schema.property_keys = Some(value.try_into()?);
+                            object_schema.property_names = Some(value.try_into()?);
                         } else {
                             return Err(unsupported_type!(
-                                "propertyKeys: Expected a mapping (subschema), but got: {:?}",
+                                "propertyNames: Expected a mapping (subschema), but got: {:?}",
                                 value
                             ));
                         }
@@ -436,13 +409,8 @@ impl ObjectSchemaBuilder {
         self
     }
 
-    pub fn property_names(&mut self, property_names: StringSchema) -> &mut Self {
-        self.0.property_names = Some(property_names);
-        self
-    }
-
-    pub fn property_keys(&mut self, schema: YamlSchema) -> &mut Self {
-        self.0.property_keys = Some(schema);
+    pub fn property_names(&mut self, schema: YamlSchema) -> &mut Self {
+        self.0.property_names = Some(schema);
         self
     }
 }
@@ -576,35 +544,35 @@ office_number: 201",
     }
 
     #[test]
-    fn test_property_keys_loads_integer_schema() {
+    fn test_property_names_loads_integer_schema() {
         let yaml = r#"
         type: object
-        propertyKeys:
+        propertyNames:
           type: integer
         "#;
         let doc = MarkedYaml::load_from_str(yaml).unwrap();
         let os: ObjectSchema = doc.first().unwrap().try_into().unwrap();
         assert!(
-            os.property_keys.is_some(),
-            "propertyKeys subschema should be loaded"
+            os.property_names.is_some(),
+            "propertyNames subschema should be loaded"
         );
     }
 
     #[test]
-    fn test_property_keys_rejects_non_mapping() {
+    fn test_property_names_rejects_non_mapping() {
         let yaml = r#"
         type: object
-        propertyKeys: integer
+        propertyNames: integer
         "#;
         let doc = MarkedYaml::load_from_str(yaml).unwrap();
         assert!(ObjectSchema::try_from(doc.first().unwrap()).is_err());
     }
 
     #[test]
-    fn test_property_keys_validation_accepts_integer_keys() {
+    fn test_property_names_validation_accepts_integer_keys() {
         let yaml = r#"
         type: object
-        propertyKeys:
+        propertyNames:
           type: integer
         "#;
         let schema: ObjectSchema = MarkedYaml::load_from_str(yaml)
@@ -620,10 +588,10 @@ office_number: 201",
     }
 
     #[test]
-    fn test_property_keys_validation_rejects_string_key() {
+    fn test_property_names_validation_rejects_string_key() {
         let yaml = r#"
         type: object
-        propertyKeys:
+        propertyNames:
           type: integer
         "#;
         let schema: ObjectSchema = MarkedYaml::load_from_str(yaml)
@@ -636,6 +604,30 @@ office_number: 201",
         let ctx = crate::Context::default();
         schema.validate(&ctx, inst.first().unwrap()).unwrap();
         assert!(ctx.has_errors(), "non-integer keys should surface errors");
+    }
+
+    #[test]
+    fn test_property_names_implicit_string_type_accepts_pattern() {
+        let yaml = r#"
+        type: object
+        propertyNames:
+          pattern: "^[a-z]+$"
+        "#;
+        let schema: ObjectSchema = MarkedYaml::load_from_str(yaml)
+            .unwrap()
+            .first()
+            .unwrap()
+            .try_into()
+            .unwrap();
+        let ok = MarkedYaml::load_from_str("alpha: 1").unwrap();
+        let ctx = crate::Context::default();
+        schema.validate(&ctx, ok.first().unwrap()).unwrap();
+        assert!(!ctx.has_errors());
+
+        let bad = MarkedYaml::load_from_str("Beta: 1").unwrap();
+        let ctx = crate::Context::default();
+        schema.validate(&ctx, bad.first().unwrap()).unwrap();
+        assert!(ctx.has_errors());
     }
 
     #[test]

--- a/src/schemas/yaml_schema.rs
+++ b/src/schemas/yaml_schema.rs
@@ -298,6 +298,16 @@ impl SchemaType {
             SchemaType::Multiple(values) => values.contains(&r#type.to_string()),
         }
     }
+
+    /// Checks if this SchemaType is `None` or `Single("string")`. Used to determine if `propertyNames`
+    /// validates the canonical string form of each key.
+    pub fn is_none_or_string(&self) -> bool {
+        match self {
+            SchemaType::None => true,
+            SchemaType::Single(s) => s == "string",
+            SchemaType::Multiple(_) => false,
+        }
+    }
 }
 
 impl Display for SchemaType {

--- a/src/validation/objects.rs
+++ b/src/validation/objects.rs
@@ -1,10 +1,12 @@
 // A module to contain object type validation logic
+use std::borrow::Cow;
 use std::collections::HashSet;
 
 use hashlink::LinkedHashMap;
 use log::debug;
+use saphyr::Scalar;
+use saphyr::YamlData;
 
-use crate::Error;
 use crate::Result;
 use crate::Validator;
 use crate::YamlSchema;
@@ -163,31 +165,16 @@ impl ObjectSchema {
                     context.record_evaluated_property(&key_string);
                 }
             }
-            // propertyKeys: YAML extension — validate each key node as an instance (before propertyNames).
-            if let Some(property_keys) = &self.property_keys {
-                let keys_context = context.append_path(&key_string);
-                property_keys.validate(&keys_context, k)?;
-            }
-            // propertyNames: string projection + pattern (JSON Schema compatible).
+            // propertyNames: validate each mapping key against the subschema.
             if let Some(property_names) = &self.property_names {
-                if let Some(re) = &property_names.pattern {
-                    debug!("Regex for property names: {}", re.as_str());
-                    if !re.is_match(key_string.as_ref()) {
-                        context.add_error(
-                            k,
-                            format!(
-                                "Property name '{}' does not match pattern '{}'",
-                                key_string,
-                                re.as_str()
-                            ),
-                        );
-                        fail_fast!(context)
-                    }
+                let names_context = context.append_path(&key_string);
+                let key_to_validate = if property_names_validates_string_projection(property_names)
+                {
+                    string_projection_of_key(k, &key_string)
                 } else {
-                    return Err(Error::GenericError(
-                        "Expected a pattern for `property_names`".to_string(),
-                    ));
-                }
+                    k.clone()
+                };
+                property_names.validate(&names_context, &key_to_validate)?;
             }
         }
 
@@ -284,6 +271,31 @@ impl ObjectSchema {
         }
         Ok(keys)
     }
+}
+
+/// Whether `propertyNames` validates the canonical string form of each key.
+fn property_names_validates_string_projection(schema: &YamlSchema) -> bool {
+    if let YamlSchema::Subschema(subschema) = schema {
+        // For composition (`oneOf` / `anyOf` / `allOf`), validating the original YAML key node is
+        // necessary so non-string key types (e.g. integer/boolean) can match their branches.
+        if subschema.one_of.is_some() || subschema.any_of.is_some() || subschema.all_of.is_some() {
+            return false;
+        }
+
+        subschema.r#type.is_none_or_string()
+    } else {
+        true
+    }
+}
+
+/// Build a key node whose value is the string projection of `key`, preserving the key span.
+fn string_projection_of_key<'r>(
+    key: &saphyr::MarkedYaml<'r>,
+    key_string: &str,
+) -> saphyr::MarkedYaml<'r> {
+    let mut projected = key.clone();
+    projected.data = YamlData::Value(Scalar::String(Cow::Owned(key_string.to_string())));
+    projected
 }
 
 #[cfg(test)]

--- a/yaml-schema.yaml
+++ b/yaml-schema.yaml
@@ -80,10 +80,11 @@ $defs:
         patternProperties:
           "^[a-zA-Z0-9_-]+$":
             $ref: "#/$defs/schema"
-      propertyKeys:
+      propertyNames:
         description: >-
-          YAML-only extension (not JSON Schema): subschema validated against each mapping
-          key node as a YAML value.
+          Subschema validated against each mapping key. When no `type` is provided, the
+          subschema is treated as `type: string` and validates the canonical string form
+          of the key. Non-string types validate the YAML key node directly.
         $ref: "#/$defs/schema"
   array_of_schemas:
     description: >-
@@ -164,10 +165,11 @@ properties:
     patternProperties:
       "^[a-zA-Z0-9_-]+$":
         $ref: "#/$defs/schema"
-  propertyKeys:
+  propertyNames:
     description: >-
-      YAML-only extension (not JSON Schema): subschema validated against each mapping key
-      node as a YAML value.
+      Subschema validated against each mapping key. When no `type` is provided, the
+      subschema is treated as `type: string` and validates the canonical string form of
+      the key. Non-string types validate the YAML key node directly.
     $ref: "#/$defs/schema"
   unevaluatedProperties:
     description: >-


### PR DESCRIPTION
## Summary

- Merges the YAML-only `propertyKeys` keyword into JSON Schema–style `propertyNames` as a full subschema validated against each mapping key.
- When `propertyNames` has no `type`, the subschema is treated as implicit `type: string` and validates the canonical string form of the key (patterns, enums, etc.).
- Non-string types (e.g. `type: integer`) validate the YAML key node directly, enabling integer/boolean mapping keys in YAML.
- Composed `propertyNames` schemas (`oneOf`, `anyOf`, `allOf`) validate the original key node so mixed key types can match their branches.

## Key changes

- **Loader/model:** `ObjectSchema.property_names` is now `Option<YamlSchema>`; `propertyKeys` is removed.
- **Validation:** String projection vs key-node selection based on type and composition keywords.
- **Meta-schema & docs:** `yaml-schema.yaml`, README, and CHANGELOG updated.
- **Tests:** Cucumber scenarios for integer keys, string enums, and `oneOf` compositions; unit tests for implicit string + pattern.

## Test plan

- [x] `cargo test --lib`
- [x] Cucumber: `Property names subschema` and related object scenarios
- [ ] Full CI on merge

Made with [Cursor](https://cursor.com)