### PR TITLE
fix: allow `required` keyword in the bundled meta-schema (#67)

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -736,6 +736,30 @@ mod tests {
         Ok(())
     }
 
+    // Regression test for https://github.com/yaml-schema/yaml-schema/issues/67:
+    // `required` must be an allowed keyword in the bundled meta-schema.
+    #[test]
+    fn test_meta_schema_accepts_required() -> Result<()> {
+        let root_schema = loader::load_file("yaml-schema.yaml")?;
+        let instance = r#"
+type: object
+properties:
+  any_property:
+    type: string
+required:
+  - any_property
+"#;
+        let context = Engine::evaluate(&root_schema, instance, false)?;
+        if context.has_errors() {
+            for error in context.errors.borrow().iter() {
+                eprintln!("{error}");
+            }
+        }
+        assert!(!context.has_errors());
+
+        Ok(())
+    }
+
     #[test]
     fn test_download_from_url() {
         // This is an integration test that requires internet access

--- a/yaml-schema.yaml
+++ b/yaml-schema.yaml
@@ -50,6 +50,11 @@ $defs:
         patternProperties:
           "^[a-zA-Z0-9_-]+$":
             $ref: "#/$defs/schema"
+      required:
+        description: An array of property names that must be present on the instance
+        type: array
+        items:
+          type: string
       description:
         type: string
       enum:
@@ -131,6 +136,11 @@ properties:
     patternProperties:
       "^[a-zA-Z0-9_-]+$":
         $ref: "#/$defs/schema"
+  required:
+    description: An array of property names that must be present on the instance
+    type: array
+    items:
+      type: string
   additionalProperties:
     oneOf:
       - type: boolean


### PR DESCRIPTION
## Summary

Fixes #67. The `required` keyword is fully validated at runtime, but the bundled meta-schema (`yaml-schema.yaml`) omitted it from its list of allowed keywords while setting `additionalProperties: false`. As a result, validating a schema document via its top-level `$schema` (i.e. `ys file.yaml` without `-f`) rejected `required` with:

```
[9:3] .: Additional property 'required' is not allowed!
```

This was a meta-schema definition gap, not a validation bug.

## Key changes

- Add `required` to `yaml-schema.yaml` in two places:
  - top-level `properties` (fixes the reported MWE for root schema files)
  - `$defs/schema` `properties` (so nested object subschemas accept `required` too)
- Add a loader regression test (`test_meta_schema_accepts_required`) that loads the bundled meta-schema and validates the exact issue #67 MWE, asserting zero errors. No network access required.

## Test plan

- [x] `cargo test test_meta_schema_accepts_required` passes
- [x] `cargo test test_self_validate` passes
- [x] `cargo run -- -f yaml-schema.yaml <mwe.yaml>` exits 0
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets` clean
- [x] Full `cargo test` suite passes (the only offline failure is the pre-existing `test_download_from_url` network test, which passes with connectivity and is gated to skip in CI)

Made with [Cursor](https://cursor.com)