### PR TITLE
feat: add pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,18 +1,6 @@
 - id: ys
   name: ys (yaml-schema)
   description: Validate YAML files against a YAML Schema
-  entry: >-
-    bash -c '
-    opts=(); files=();
-    while [ $# -gt 0 ]; do
-      case "$1" in
-        -f|--schema) opts+=("$1" "$2"); shift 2 ;;
-        -*) opts+=("$1"); shift 1 ;;
-        *) files+=("$1"); shift 1 ;;
-      esac
-    done;
-    for f in "${files[@]}"; do
-      ys "${opts[@]}" "$f" || exit 1;
-    done' --
+  entry: ys
   language: rust
   types: [yaml]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,18 @@
 - id: ys
   name: ys (yaml-schema)
   description: Validate YAML files against a YAML Schema
-  entry: ys
+  entry: >-
+    bash -c '
+    opts=(); files=();
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        -f|--schema) opts+=("$1" "$2"); shift 2 ;;
+        -*) opts+=("$1"); shift 1 ;;
+        *) files+=("$1"); shift 1 ;;
+      esac
+    done;
+    for f in "${files[@]}"; do
+      ys "${opts[@]}" "$f" || exit 1;
+    done' --
   language: rust
   types: [yaml]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: ys
+  name: ys (yaml-schema)
+  description: Validate YAML files against a YAML Schema
+  entry: ys
+  language: rust
+  types: [yaml]


### PR DESCRIPTION
Thank you for developing this excellent tool. It has quickly become my favorite YAML Schema validator.

Now, I'd also like to adopt it in a team context. Most of my projects already use pre-commit for quality control. This PR adds the pre-commit hook that supports running `ys` at commit time, revealing schema violations as they are made.

Here's my proof of concept in a real project: [basic config](https://github.com/SCF-Public-Goods-Maintenance/pg-atlas-backend/pull/72/changes/a34385bddfad3e9f80bd51dc3d3fb4132bb5f444#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9) for a single schema that validates a directory of files. Only files modified in the commit are validated.

It works fine as a local pre-commit hook. Some changes are still required to make it work on CI runners, for a reason that surprised me: https://github.com/pre-commit-ci/issues/issues/270

To get past the CI build failure for this hook, one of two things needs to happen.

1. OpenSSL headers would need to be added to a no-network-access environment
2. The `reqwest` dependency needs to be put behind a feature

I haven't checked why the dependency on `reqwest` exists. My guess is that there's some support for remote schema fetching. Would you be willing to make this optional, at compile time?