### PR TITLE
fix: unbreak cargo bench (boon $schema draft detection)

### DIFF
--- a/benches/ys_vs_boon.rs
+++ b/benches/ys_vs_boon.rs
@@ -1,5 +1,6 @@
 use std::fs::File;
 use std::fs::read_to_string;
+use std::time::Duration;
 
 use criterion::Criterion;
 use criterion::criterion_group;
@@ -7,7 +8,8 @@ use criterion::criterion_main;
 
 fn bench(c: &mut Criterion) {
     let mut group = c.benchmark_group("ys_vs_boon");
-    group.sample_size(1000);
+    group.sample_size(10000);
+    group.measurement_time(Duration::from_secs(10));
     group.bench_function("boon", |b| b.iter(boon));
     group.bench_function("ys", |b| b.iter(ys));
     group.finish();
@@ -35,6 +37,21 @@ fn boon() {
     let mut loader = boon::SchemeUrlLoader::new();
     loader.register("file", Box::new(FileUrlLoader));
     compiler.use_loader(Box::new(loader));
+
+    let mut schema_value: serde_json::Value = serde_yaml::from_reader(
+        File::open("yaml-schema.yaml").expect("Failed to open YAML file"),
+    )
+    .expect("Failed to read YAML file");
+    // yaml-schema.yaml's `$schema` is a self-referential, non-standard meta-schema URL
+    // that boon can't resolve to a known JSON Schema draft (boon explicitly rejects a
+    // schema whose `$schema` points back at itself). Drop it so boon falls back to its
+    // default (latest) draft instead.
+    if let Some(obj) = schema_value.as_object_mut() {
+        obj.remove("$schema");
+    }
+    compiler
+        .add_resource("yaml-schema.yaml", schema_value)
+        .expect("Failed to add resource");
     let sch_index = compiler
         .compile("yaml-schema.yaml", &mut schemas)
         .expect("Failed to compile schema");

--- a/benches/ys_vs_boon.rs
+++ b/benches/ys_vs_boon.rs
@@ -38,10 +38,9 @@ fn boon() {
     loader.register("file", Box::new(FileUrlLoader));
     compiler.use_loader(Box::new(loader));
 
-    let mut schema_value: serde_json::Value = serde_yaml::from_reader(
-        File::open("yaml-schema.yaml").expect("Failed to open YAML file"),
-    )
-    .expect("Failed to read YAML file");
+    let mut schema_value: serde_json::Value =
+        serde_yaml::from_reader(File::open("yaml-schema.yaml").expect("Failed to open YAML file"))
+            .expect("Failed to read YAML file");
     // yaml-schema.yaml's `$schema` is a self-referential, non-standard meta-schema URL
     // that boon can't resolve to a known JSON Schema draft (boon explicitly rejects a
     // schema whose `$schema` points back at itself). Drop it so boon falls back to its


### PR DESCRIPTION
## Summary
- `cargo bench` was panicking: `boon`'s compiler explicitly rejects a schema whose `$schema` field is self-referential, which is what `yaml-schema.yaml` declares (`https://yaml-schema.net/yaml-schema.yaml`). This crashed the `ys_vs_boon` benchmark before any measurements could run.
- Fix: strip `$schema` from the parsed value before handing it to `boon::Compiler::add_resource`, so `boon` falls back to its default (latest) draft instead of trying to resolve the custom dialect URL. `yaml_schema`'s own `Engine::evaluate` never needed `$schema` resolution for self-validation, so only the `boon` side was affected.
- Also bumped `sample_size` to 10000 and added an explicit 10s `measurement_time` for more stable benchmark runs.

## Changes
- `benches/ys_vs_boon.rs`: load `yaml-schema.yaml` into a `serde_json::Value`, remove `$schema`, register it as a resource via `add_resource` instead of relying on the URL loader for the top-level compile; bumped criterion sampling config.

## Testing
- `cargo bench` completes end-to-end without panicking (previously failed with `LoadUrlError { ... UnsupportedUrlScheme }` / `UnsupportedDraft`).
- `cargo fmt --check`, `cargo clippy --all-targets`, and `cargo test` (197 passed) all pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZBw8jZtiiWiVPf2zkf1RW